### PR TITLE
BDouble String Initializer and Optionals

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,19 +35,19 @@ This subsection explains the usage of BInt and BDouble
 ```swift
 BInt(Int)
 BInt(UInt)
-BInt(String)
+BInt(String)?
 ```
 
 #### Examples:
 ```swift
 let i = BInt(12)
 let i = BInt(-9234)
-let i = BInt("-2343241765837645983267582365876326491813491053680428560284652986203287826526")
+let i = BInt("-2343241765837645983267582365876326491813491053680428560284652986203287826526")!
 ```
 
 #### BInt offers 7 struct methods:
 ```swift
-let big = BInt("-143141341")
+let big = BInt("-143141341")!
 
 big.description // Returns "-143141341"
 => print(big) // prints "-143141341"
@@ -150,8 +150,9 @@ public func nnmod(_ a: BInt, _ m: BInt) -> BInt
 ```swift
 BDouble(Int)
 BDouble(Double)
+BDouble(String)?
 BDouble(Int, over: Int)
-BDouble(String, over: String)
+BDouble(String, over: String)?
 ```
 
 #### Examples:
@@ -159,7 +160,7 @@ BDouble(String, over: String)
 let d = BDouble(221)
 let d = BDouble(1.192)
 let d = BDouble(3, over: 4)
-let d = BDouble("1" over: "3421342675925672365438867862653658268376582356831563158967")
+let d = BDouble("1" over: "3421342675925672365438867862653658268376582356831563158967")!
 ```
 
 #### BDouble offers these struct methods:

--- a/Sources/SMP.swift
+++ b/Sources/SMP.swift
@@ -249,15 +249,15 @@ public struct BInt:
 		var sign = false
 		var base: Limbs = [1]
 		var limbs: Limbs = [0]
-	
+
 		limbs.reserveCapacity(Int(Double(str.count) / log10(pow(2.0, 64.0))))
-	
+
 		if str.hasPrefix("-")
 		{
 			str.remove(at: str.startIndex)
 			sign = str != "0"
 		}
-	
+
 		for chunk in String(str.reversed()).split(19).map({ String($0.reversed()) })
 		{
 			if let num = Limb(String(chunk))
@@ -270,7 +270,7 @@ public struct BInt:
 				return nil
 			}
 		}
-	
+
 		self.init(sign: sign, limbs: limbs)
 	}
 
@@ -348,7 +348,7 @@ public struct BInt:
 	{
 		let str = self.limbs.decimalRepresentation
 		let newStr = str.convertingBase(from: 10, toBase: base)
-	
+
 		if self.sign { return "-".appending(newStr) }
 		return newStr
 	}
@@ -368,23 +368,23 @@ public struct BInt:
 	{
 		//	Conversion only works when self has only one limb thats smaller or
 		//	equal to abs(Int.min).
-	
+
 		if self.limbs.count != 1 { return nil }
-	
+
 		let number = self.limbs[0]
-	
+
 		//	Self is within the range of Int
 		if number <= Limb(Int.max)
 		{
 			return self.sign ? -Int(number) : Int(number)
 		}
-	
+
 		//	Special case: self == Int.min
 		if number == (Limb(Int.max) + 1) && self.sign
 		{
 			return Int.min
 		}
-	
+
 		return nil
 	}
 
@@ -419,7 +419,6 @@ public struct BInt:
 	func isOdd()      -> Bool { return self.limbs[0] & 1 == 1 }
 	func isEven()     -> Bool { return self.limbs[0] & 1 == 0 }
 
-
 	///	The number of bits in the current binary representation of this value.
 	public var bitWidth: Int
 	{
@@ -450,10 +449,10 @@ public struct BInt:
 	public static func <<<T: BinaryInteger>(lhs: BInt, rhs: T) -> BInt
 	{
 		if rhs < 0 { return lhs >> rhs }
-	
+
 		let limbs = lhs.limbs.shiftingUp(Int(rhs))
 		let sign = lhs.isNegative() && !limbs.equalTo(0)
-	
+
 		return BInt(sign: sign, limbs: limbs)
 	}
 
@@ -487,16 +486,15 @@ public struct BInt:
 	public static func &(lhs: BInt, rhs: BInt) -> BInt
 	{
 		var res: Limbs = [0]
-	
+
 		for i in 0..<(64 * Swift.max(lhs.limbs.count, rhs.limbs.count))
 		{
 			let newBit = lhs.limbs.getBit(at: i) && lhs.limbs.getBit(at: i)
 			res.setBit(at: i, to: newBit)
 		}
-	
+
 		return BInt(sign: lhs.sign && rhs.sign, limbs: res)
 	}
-
 
 	//	static func &(lhs: Int, rhs: BInt) -> BInt
 	//	static func &(lhs: BInt, rhs: Int) -> BInt
@@ -525,13 +523,13 @@ public struct BInt:
 	public static func |(lhs: BInt, rhs: BInt) -> BInt
 	{
 		var res: Limbs = [0]
-	
+
 		for i in 0..<(64 * Swift.max(lhs.limbs.count, rhs.limbs.count))
 		{
 			let newBit = lhs.limbs.getBit(at: i) || lhs.limbs.getBit(at: i)
 			res.setBit(at: i, to: newBit)
 		}
-	
+
 		return BInt(sign: lhs.sign || rhs.sign, limbs: res)
 	}
 
@@ -559,13 +557,13 @@ public struct BInt:
 	public static func ^(lhs: BInt, rhs: BInt) -> BInt
 	{
 		var res: Limbs = [0]
-	
+
 		for i in 0..<(64 * Swift.max(lhs.limbs.count, rhs.limbs.count))
 		{
 			let newBit = lhs.limbs.getBit(at: i) != lhs.limbs.getBit(at: i)
 			res.setBit(at: i, to: newBit)
 		}
-	
+
 		return BInt(sign: lhs.sign != rhs.sign, limbs: res)
 	}
 
@@ -592,9 +590,9 @@ public struct BInt:
 		{
 			res.setBit(at: i, to: !res.getBit(at: i))
 		}
-	
+
 		while res.last! == 0 && res.count > 1 { res.removeLast() }
-	
+
 		return BInt(sign: !x.sign, limbs: res)
 	}
 
@@ -621,11 +619,11 @@ public struct BInt:
 			lhs.limbs.addLimbs(rhs.limbs)
 			return
 		}
-	
+
 		let rhsIsMin = rhs.limbs.lessThan(lhs.limbs)
 		lhs.limbs.difference(rhs.limbs)
 		lhs.sign = (rhs.sign && !rhsIsMin) || (lhs.sign && rhsIsMin) // DNF minimization
-	
+
 		if lhs.isZero() { lhs.sign = false }
 	}
 
@@ -735,7 +733,7 @@ public struct BInt:
 	func factorial() -> BInt
 	{
 		precondition(!self.sign, "Can't calculate the factorial of an negative number")
-	
+
 		return BInt(limbs: Limbs.recursiveMul(0, Limb(self.toInt()!)))
 	}
 
@@ -760,7 +758,7 @@ public struct BInt:
 	{
 		let limbs = lhs.limbs.divMod(rhs.limbs).quotient
 		let sign = (lhs.sign != rhs.sign) && !limbs.equalTo(0)
-	
+
 		return BInt(sign: sign, limbs: limbs)
 	}
 
@@ -784,7 +782,7 @@ public struct BInt:
 	{
 		let limbs = lhs.limbs.divMod(rhs.limbs).remainder
 		let sign = lhs.sign && !limbs.equalTo(0)
-	
+
 		return BInt(sign: sign, limbs: limbs)
 	}
 
@@ -793,7 +791,6 @@ public struct BInt:
 
 	public static func %=(lhs: inout BInt, rhs: BInt)  { lhs = lhs % rhs       }
 	static func %=(lhs: inout BInt, rhs:  Int)  { lhs = lhs % BInt(rhs) }
-
 
 	//
 	//
@@ -834,12 +831,11 @@ public struct BInt:
 
 	static func !=<T: BinaryInteger>(lhs: T, rhs: BInt) -> Bool { return rhs != lhs }
 
-
 	// Required by protocol Comparable
 	public static func <(lhs: BInt, rhs: BInt) -> Bool
 	{
 		if lhs.sign != rhs.sign { return lhs.sign }
-	
+
 		if lhs.sign { return rhs.limbs.lessThan(lhs.limbs) }
 		return lhs.limbs.lessThan(rhs.limbs)
 	}
@@ -847,7 +843,7 @@ public struct BInt:
 	static func <<T: BinaryInteger>(lhs: BInt, rhs: T) -> Bool
 	{
 		if lhs.sign != (rhs < 0) { return lhs.sign }
-	
+
 		if lhs.sign
 		{
 			if lhs.limbs.count != 1 { return true }
@@ -858,7 +854,7 @@ public struct BInt:
 			if lhs.limbs.count != 1 { return false }
 			return lhs.limbs[0] < rhs
 		}
-	
+
 	}
 
 	static func <(lhs:  Int, rhs: BInt) -> Bool { return BInt(lhs) < rhs }
@@ -915,25 +911,25 @@ fileprivate extension String
 			"M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X",
 			"Y", "Z"
 		]
-	
+
 		var res = ""
 		var number = self
-	
+
 		if number.hasPrefix("-")
 		{
 			res = "-"
 			number.removeFirst()
 		}
-	
+
 		var sum = BInt(0)
 		var multiplier = BInt(1)
-	
+
 		for char in number.reversed()
 		{
 			if let digit = chars.index(of: char)
 			{
 				precondition(digit < from)
-			
+
 				sum += digit * multiplier
 				multiplier *= from
 			}
@@ -942,14 +938,14 @@ fileprivate extension String
 				fatalError()
 			}
 		}
-	
+
 		repeat
 		{
 			res.insert(chars[(sum % toBase).toInt()!], at: res.startIndex)
 			sum /= BInt(toBase)
 		}
 			while sum != 0
-	
+
 		return res
 	}
 }
@@ -963,34 +959,34 @@ fileprivate extension Array where Element == Limb
 		// First, convert limbs to digits
 		var digits: Digits = [0]
 		var power: Digits = [1]
-	
+
 		for limb in self
 		{
 			let digit = (limb >= DigitBase)
 				? [limb % DigitBase, limb / DigitBase]
 				: [limb]
-		
+
 			digits.addProductOfDigits(digit, power)
-		
+
 			var nextPower: Digits = [0]
 			nextPower.addProductOfDigits(power, [446_744_073_709_551_616, 18])
 			power = nextPower
 		}
-	
+
 		// Then, convert digits to string
 		var res = String(digits.last!)
-	
+
 		if digits.count == 1 { return res }
-	
+
 		for i in (0..<(digits.count - 1)).reversed()
 		{
 			let str = String(digits[i])
-		
+
 			let leadingZeros = String(repeating: "0", count: DigitZeros - str.count)
-		
+
 			res.append(leadingZeros.appending(str))
 		}
-	
+
 		return res
 	}
 }
@@ -1007,18 +1003,18 @@ fileprivate extension Digit
 	{
 		let (lLo, lHi) = (self % DigitHalfBase, self / DigitHalfBase)
 		let (rLo, rHi) = (multiplicand % DigitHalfBase, multiplicand / DigitHalfBase)
-	
+
 		let K = (lHi * rLo) + (rHi * lLo)
-	
+
 		var resLo = (lLo * rLo) + ((K % DigitHalfBase) * DigitHalfBase)
 		var resHi = (lHi * rHi) + (K / DigitHalfBase)
-	
+
 		if resLo >= DigitBase
 		{
 			resLo -= DigitBase
 			resHi += 1
 		}
-	
+
 		return (resLo, resHi)
 	}
 }
@@ -1029,15 +1025,15 @@ fileprivate extension Array where Element == Digit
 		padding paddingZeros: Int
 		){
 		let sc = self.count
-	
+
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self.append(addend); return }
-	
+
 		// Now, i < sc
 		var i = paddingZeros
-	
+
 		let ovfl = self[i].addReportingOverflowDigit(addend)
-	
+
 		while ovfl
 		{
 			i += 1
@@ -1054,17 +1050,17 @@ fileprivate extension Array where Element == Digit
 		padding paddingZeros: Int)
 	{
 		let sc = self.count
-	
+
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self += [addendLow, addendHigh]; return }
-	
+
 		// Now, i < sc
 		var i = paddingZeros
 		var newDigit: Digit
-	
+
 		let ovfl1 = self[i].addReportingOverflowDigit(addendLow)
 		i += 1
-	
+
 		if i == sc
 		{
 			newDigit = (addendHigh &+ (ovfl1 ? 1 : 0)) % DigitBase
@@ -1072,7 +1068,7 @@ fileprivate extension Array where Element == Digit
 			if newDigit == 0 { self.append(1) }
 			return
 		}
-	
+
 		// Still, i < sc
 		var ovfl2 = self[i].addReportingOverflowDigit(addendHigh)
 		if ovfl1
@@ -1080,7 +1076,7 @@ fileprivate extension Array where Element == Digit
 			self[i] += 1
 			if self[i] == DigitBase { self[i] = 0; ovfl2 = true }
 		}
-	
+
 		while ovfl2
 		{
 			i += 1
@@ -1095,21 +1091,21 @@ fileprivate extension Array where Element == Digit
 	{
 		let (mpc, mcc) = (multiplier.count, multiplicand.count)
 		self.reserveCapacity(mpc &+ mcc)
-	
+
 		var l, r, resLo, resHi: Digit
-	
+
 		for i in 0..<mpc
 		{
 			l = multiplier[i]
 			if l == 0 { continue }
-		
+
 			for j in 0..<mcc
 			{
 				r = multiplicand[j]
 				if r == 0 { continue }
-			
+
 				(resLo, resHi) = l.multipliedFullWidthDigit(by: r)
-			
+
 				if resHi == 0
 				{
 					self.addOneDigit(resLo, padding: i + j)
@@ -1154,12 +1150,12 @@ fileprivate extension Array where Element == Limb
 	{
 		var lastBits = 0
 		var last = self.last!
-	
+
 		while last != 0 {
 			last >>= 1
 			lastBits += 1
 		}
-	
+
 		return ((self.count - 1) * 64) + lastBits
 	}
 
@@ -1167,11 +1163,11 @@ fileprivate extension Array where Element == Limb
 	func getBit(at i: Int) -> Bool
 	{
 		let limbIndex = Int(Limb(i) >> 6)
-	
+
 		if limbIndex >= self.count { return false }
-	
+
 		let bitIndex = Limb(i) & 0b111_111
-	
+
 		return (self[limbIndex] & (1 << bitIndex)) != 0
 	}
 
@@ -1181,13 +1177,13 @@ fileprivate extension Array where Element == Limb
 		to bit: Bool
 		){
 		let limbIndex = Int(Limb(i) >> 6)
-	
+
 		if limbIndex >= self.count && !bit { return }
-	
+
 		let bitIndex = Limb(i) & 0b111_111
-	
+
 		while limbIndex >= self.count { self.append(0) }
-	
+
 		if bit
 		{
 			self[limbIndex] |= (1 << bitIndex)
@@ -1212,32 +1208,32 @@ fileprivate extension Array where Element == Limb
 	{
 		// No shifting is required in this case
 		if shift == 0 || self.equalTo(0) { return }
-	
+
 		let limbShifts =  shift >> 6
 		let bitShifts = Limb(shift) & 0x3f
-	
+
 		if bitShifts != 0
 		{
 			var previousCarry = Limb(0)
 			var carry = Limb(0)
 			var ele = Limb(0) // use variable to minimize array accesses
-		
+
 			for i in 0..<self.count
 			{
 				ele = self[i]
-			
+
 				carry = ele >> (64 - bitShifts)
-			
+
 				ele <<= bitShifts
 				ele |= previousCarry // carry from last step
 				previousCarry = carry
-			
+
 				self[i] = ele
 			}
-		
+
 			if previousCarry != 0 { self.append(previousCarry) }
 		}
-	
+
 		if limbShifts != 0
 		{
 			self.insert(contentsOf: Limbs(repeating: 0, count: limbShifts), at: 0)
@@ -1254,41 +1250,41 @@ fileprivate extension Array where Element == Limb
 	mutating func shiftDown(_ shift: Int)
 	{
 		if shift == 0 || self.equalTo(0) { return }
-	
+
 		let limbShifts =  shift >> 6
 		let bitShifts = Limb(shift) & 0x3f
-	
+
 		if limbShifts >= self.count
 		{
 			self = [0]
 			return
 		}
-	
+
 		self.removeSubrange(0..<limbShifts)
-	
+
 		if bitShifts != 0
 		{
 			var previousCarry = Limb(0)
 			var carry = Limb(0)
 			var ele = Limb(0) // use variable to minimize array accesses
-		
+
 			var i = self.count - 1 // use while for high performance
 			while i >= 0
 			{
 				ele = self[i]
-			
+
 				carry = ele << (64 - bitShifts)
-			
+
 				ele >>= bitShifts
 				ele |= previousCarry
 				previousCarry = carry
-			
+
 				self[i] = ele
-			
+
 				i -= 1
 			}
 		}
-	
+
 		if self.last! == 0 && self.count != 1 { self.removeLast() }
 	}
 
@@ -1312,11 +1308,11 @@ fileprivate extension Array where Element == Limb
 	mutating func addLimbs(_ addend: Limbs)
 	{
 		let (sc, ac) = (self.count, addend.count)
-	
+
 		var (newLimb, ovfl) = (Limb(0), false)
-	
+
 		let minCount = Swift.min(sc, ac)
-	
+
 		var i = 0
 		while i < minCount
 		{
@@ -1324,18 +1320,18 @@ fileprivate extension Array where Element == Limb
 			{
 				(newLimb, ovfl) =  self[i].addingReportingOverflow(addend[i])
 				newLimb = newLimb &+ 1
-			
+
 				ovfl = ovfl || newLimb == 0
 			}
 			else
 			{
 				(newLimb, ovfl) = self[i].addingReportingOverflow(addend[i])
 			}
-		
+
 			self[i] = newLimb
 			i += 1
 		}
-	
+
 		while ovfl
 		{
 			if i < sc
@@ -1350,7 +1346,7 @@ fileprivate extension Array where Element == Limb
 				{
 					(newLimb, ovfl) = self[i].addingReportingOverflow(1)
 				}
-			
+
 				self[i] = newLimb
 			}
 			else
@@ -1366,10 +1362,10 @@ fileprivate extension Array where Element == Limb
 					return
 				}
 			}
-		
+
 			i += 1
 		}
-	
+
 		if self.count < ac
 		{
 			self.append(contentsOf: addend.suffix(from: i))
@@ -1392,17 +1388,17 @@ fileprivate extension Array where Element == Limb
 		padding paddingZeros: Int
 		){
 		let sc = self.count
-	
+
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self += addend; return }
-	
+
 		// Now, i < sc
 		let ac = addend.count &+ paddingZeros
-	
+
 		var (newLimb, ovfl) = (Limb(0), false)
-	
+
 		let minCount = Swift.min(sc, ac)
-	
+
 		var i = paddingZeros
 		while i < minCount
 		{
@@ -1417,10 +1413,10 @@ fileprivate extension Array where Element == Limb
 			{
 				(self[i], ovfl) = self[i].addingReportingOverflow(addend[i &- paddingZeros])
 			}
-		
+
 			i += 1
 		}
-	
+
 		while ovfl
 		{
 			if i < sc
@@ -1442,10 +1438,10 @@ fileprivate extension Array where Element == Limb
 					return
 				}
 			}
-		
+
 			i += 1
 		}
-	
+
 		if self.count < ac
 		{
 			self.append(contentsOf: addend.suffix(from: i &- paddingZeros))
@@ -1457,16 +1453,16 @@ fileprivate extension Array where Element == Limb
 		padding paddingZeros: Int
 		){
 		let sc = self.count
-	
+
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self.append(addend); return }
-	
+
 		// Now, i < lhc
 		var i = paddingZeros
-	
+
 		var ovfl: Bool
 		(self[i], ovfl) = self[i].addingReportingOverflow(addend)
-	
+
 		while ovfl
 		{
 			i += 1
@@ -1482,18 +1478,18 @@ fileprivate extension Array where Element == Limb
 		padding paddingZeros: Int)
 	{
 		let sc = self.count
-	
+
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self += [addendLow, addendHigh]; return }
-	
+
 		// Now, i < sc
 		var i = paddingZeros
 		var newLimb: Limb
-	
+
 		var ovfl1: Bool
 		(self[i], ovfl1) =  self[i].addingReportingOverflow(addendLow)
 		i += 1
-	
+
 		if i == sc
 		{
 			newLimb = addendHigh &+ (ovfl1 ? 1 : 0)
@@ -1501,17 +1497,17 @@ fileprivate extension Array where Element == Limb
 			if newLimb == 0 { self.append(1) }
 			return
 		}
-	
+
 		// Still, i < sc
 		var ovfl2: Bool
 		(self[i], ovfl2) = self[i].addingReportingOverflow(addendHigh)
-	
+
 		if ovfl1
 		{
 			self[i] = self[i] &+ 1
 			if self[i] == 0 { ovfl2 = true }
 		}
-	
+
 		while ovfl2
 		{
 			i += 1
@@ -1536,15 +1532,15 @@ fileprivate extension Array where Element == Limb
 		var subtrahend = subtrahend
 		// swap to get difference
 		if self.lessThan(subtrahend) { swap(&self, &subtrahend) }
-	
+
 		let rhc = subtrahend.count
 		var ovfl = false
-	
+
 		var i = 0
-	
+
 		// skip first zeros
 		while i < rhc && subtrahend[i] == 0 { i += 1 }
-	
+
 		while i < rhc
 		{
 			if ovfl
@@ -1557,10 +1553,10 @@ fileprivate extension Array where Element == Limb
 			{
 				(self[i], ovfl) = self[i].subtractingReportingOverflow(subtrahend[i])
 			}
-		
+
 			i += 1
 		}
-	
+
 		while ovfl
 		{
 			if i >= self.count
@@ -1568,17 +1564,17 @@ fileprivate extension Array where Element == Limb
 				self.append(Limb.max)
 				break
 			}
-		
+
 			(self[i], ovfl) = self[i].subtractingReportingOverflow(1)
-		
+
 			i += 1
 		}
-	
+
 		if self.count > 1 && self.last! == 0 // cut excess zeros if required
 		{
 			var j = self.count - 2
 			while j >= 1 && self[j] == 0 { j -= 1 }
-		
+
 			self.removeSubrange((j + 1)..<self.count)
 		}
 	}
@@ -1605,24 +1601,24 @@ fileprivate extension Array where Element == Limb
 		multiplicand: Limbs
 		){
 		let (mpc, mcc) = (multiplier.count, multiplicand.count)
-	
+
 		self.reserveCapacity(mpc + mcc)
-	
+
 		// Minimize array subscript calls
 		var l, r, mulHi, mulLo: Limb
-	
+
 		for i in 0..<mpc
 		{
 			l = multiplier[i]
 			if l == 0 { continue }
-		
+
 			for j in 0..<mcc
 			{
 				r = multiplicand[j]
 				if r == 0 { continue }
-			
+
 				(mulHi, mulLo) = l.multipliedFullWidth(by: r)
-			
+
 				if mulHi != 0 { self.addTwoLimb(mulLo, mulHi, padding: i + j) }
 				else          { self.addOneLimb(mulLo,        padding: i + j) }
 			}
@@ -1640,17 +1636,17 @@ fileprivate extension Array where Element == Limb
 			// If r == 0 then do nothing with res
 			return
 		}
-	
+
 		// Minimize array subscript calls
 		var l, mulHi, mulLo: Limb
-	
+
 		for i in 0..<multiplier.count
 		{
 			l = multiplier[i]
 			if l == 0 { continue }
-		
+
 			(mulHi, mulLo) = l.multipliedFullWidth(by: multiplicand)
-		
+
 			if mulHi != 0 { self.addTwoLimb(mulLo, mulHi, padding: i) }
 			else {          self.addOneLimb(mulLo,        padding: i) }
 		}
@@ -1667,22 +1663,22 @@ fileprivate extension Array where Element == Limb
 	{
 		var res: Limbs = [0]
 		res.reserveCapacity(2 * self.count)
-	
+
 		// Minimize array subscript calls
 		var l, r, mulHi, mulLo: Limb
-	
+
 		for i in 0..<self.count
 		{
 			l = self[i]
 			if l == 0 { continue }
-		
+
 			for j in 0...i
 			{
 				r = self[j]
 				if r == 0 { continue }
-			
+
 				(mulHi, mulLo) = l.multipliedFullWidth(by: r)
-			
+
 				if mulHi != 0
 				{
 					if i != j { res.addTwoLimb(mulLo, mulHi, padding: i + j) }
@@ -1695,7 +1691,7 @@ fileprivate extension Array where Element == Limb
 				}
 			}
 		}
-	
+
 		return res
 	}
 
@@ -1714,18 +1710,18 @@ fileprivate extension Array where Element == Limb
 	{
 		if exponent == 0 { return [1] }
 		if exponent == 1 { return self }
-	
+
 		var base = self
 		var exponent = exponent
 		var y: Limbs = [1]
-	
+
 		while exponent > 1
 		{
 			if exponent & 1 != 0 { y = y.multiplyingBy(base) }
 			base = base.squared()
 			exponent >>= 1
 		}
-	
+
 		return base.multiplyingBy(y)
 	}
 
@@ -1733,9 +1729,9 @@ fileprivate extension Array where Element == Limb
 	static func recursiveMul(_ n: Limb, _ k: Limb) -> Limbs
 	{
 		if n >= k - 1 { return [k] }
-	
+
 		let m = (n + k) >> 1
-	
+
 		return recursiveMul(n, m).multiplyingBy(recursiveMul(m, k))
 	}
 
@@ -1758,15 +1754,15 @@ fileprivate extension Array where Element == Limb
 	func divMod(_ divisor: Limbs) -> (quotient: Limbs, remainder: Limbs)
 	{
 		precondition(!divisor.equalTo(0), "Division or Modulo by zero not allowed")
-	
+
 		if self.equalTo(0) { return ([0], [0]) }
-	
+
 		var (quotient, remainder): (Limbs, Limbs) = ([0], [0])
 		var (previousCarry, carry, ele): (Limb, Limb, Limb) = (0, 0, 0)
-	
+
 		// bits of lhs minus one bit
 		var i = (64 * (self.count - 1)) + Int(log2(Double(self.last!)))
-	
+
 		while i >= 0
 		{
 			// shift remainder by 1 to the left
@@ -1780,18 +1776,18 @@ fileprivate extension Array where Element == Limb
 				remainder[r] = ele
 			}
 			if previousCarry != 0 { remainder.append(previousCarry) }
-		
+
 			remainder.setBit(at: 0, to: self.getBit(at: i))
-		
+
 			if !remainder.lessThan(divisor)
 			{
 				remainder.difference(divisor)
 				quotient.setBit(at: i, to: true)
 			}
-		
+
 			i -= 1
 		}
-	
+
 		return (quotient, remainder)
 	}
 
@@ -1828,19 +1824,19 @@ fileprivate extension Array where Element == Limb
 	{
 		let lhsc = self.count
 		let rhsc = compare.count
-	
+
 		if lhsc != rhsc
 		{
 			return lhsc < rhsc
 		}
-	
+
 		var i = lhsc - 1
 		while i >= 0
 		{
 			if self[i] != compare[i] { return self[i] < compare[i] }
 			i -= 1
 		}
-	
+
 		return false // lhs == rhs
 	}
 
@@ -1868,19 +1864,19 @@ public class BIntMath
 	static func isMersenne(_ exp: Int) -> Bool
 	{
 		var mersenne = Limbs(repeating: Limb.max, count: exp >> 6)
-	
+
 		if (exp % 64) > 0
 		{
 			mersenne.append((Limb(1) << Limb(exp % 64)) - Limb(1))
 		}
-	
+
 		var res: Limbs = [4]
-	
+
 		for _ in 0..<(exp - 2)
 		{
 			res = res.squared().differencing([2]).divMod(mersenne).remainder
 		}
-	
+
 		return res.equalTo(0)
 	}
 
@@ -1903,28 +1899,28 @@ public class BIntMath
 	static func steinGcd(_ a: BInt, _ b: BInt) -> BInt
 	{
 		if a.isZero() { return b }
-	
+
 		var (a, b, k) = (a, b, 0)
-	
+
 		while a.isEven() && b.isEven()
 		{
 			a >>= 1
 			b >>= 1
 			k += 1
 		}
-	
+
 		var t = a.isOdd() ? -b : a
-	
+
 		while !t.isZero()
 		{
 			while t.isEven() { t >>= 1 }
-		
+
 			if  t > 0 { a =  t }
 			else      { b = -t }
-		
+
 			t = a - b
 		}
-	
+
 		return a << k
 	}
 
@@ -1947,17 +1943,16 @@ public class BIntMath
 	static func fib(_ n:Int) -> BInt
 	{
 		var a: Limbs = [0], b: Limbs = [1], t: Limbs
-	
+
 		for _ in 2...n
 		{
 			t = b
 			b.addLimbs(a)
 			a = t
 		}
-	
+
 		return BInt(limbs: b)
 	}
-
 
 	///	Order matters, repetition not allowed.
 	static func permutations(_ n: Int, _ k: Int) -> BInt
@@ -1971,7 +1966,7 @@ public class BIntMath
 	{
 		// n ** k
 		return BInt(n) ** k
-	
+
 	}
 
 	///	Order does not matter, repetition not allowed.
@@ -1992,23 +1987,23 @@ public class BIntMath
 	{
 		let limbs = n >> 6
 		let singleBits = n % 64
-	
+
 		var res = Limbs(repeating: 0, count: Int(limbs))
-	
+
 		for i in 0..<Int(limbs)
 		{
 			res[i] = Limb(arc4random_uniform(UInt32.max)) |
 				(Limb(arc4random_uniform(UInt32.max)) << 32)
 		}
-	
+
 		if singleBits > 0
 		{
 			var last: Limb
-		
+
 			if singleBits < 32
 			{
 				last = Limb(arc4random_uniform(UInt32(2 ** singleBits)))
-			
+
 			}
 			else if singleBits == 32
 			{
@@ -2019,19 +2014,19 @@ public class BIntMath
 				last = Limb(arc4random_uniform(UInt32.max)) |
 					(Limb(arc4random_uniform(UInt32(2 ** (singleBits - 32)))) << 32)
 			}
-		
+
 			res.append(last)
 		}
-	
+
 		return BInt(limbs: res)
 	}
 
 	func isPrime(_ n: BInt) -> Bool
 	{
 		if n <= 3 { return n > 1 }
-	
+
 		if ((n % 2) == 0) || ((n % 3) == 0) { return false }
-	
+
 		var i = 5
 		while (i * i) <= n
 		{
@@ -2043,7 +2038,6 @@ public class BIntMath
 		}
 		return true
 	}
-
 
 	/// Quick exponentiation/modulo algorithm
 	/// FIXME: for security, this should use the constant-time Montgomery algorithm to thwart timing attacks
@@ -2070,7 +2064,6 @@ public class BIntMath
 		return result
 	}
 
-
 	/// Non-negative modulo operation
 	///
 	/// - Parameters:
@@ -2083,7 +2076,6 @@ public class BIntMath
 		let p = m.isNegative() ? r - m : r + m
 		return p
 	}
-
 
 	/// Convenience function combinding addition and non-negative modulo operations
 	///
@@ -2127,7 +2119,6 @@ public struct BDouble:
 		lhs = res
 	}
 
-
 	public init?<T>(exactly source: T) where T : BinaryInteger {
 		self.init(0.0)
 	}
@@ -2161,11 +2152,11 @@ public struct BDouble:
 			!denominator.equalTo(0) && denominator != [] && numerator != [],
 			"Denominator can't be zero and limbs can't be []"
 		)
-	
+
 		self.sign = sign
 		self.numerator = numerator
 		self.denominator = denominator
-	
+
 		self.minimize()
 	}
 
@@ -2208,13 +2199,13 @@ public struct BDouble:
 				let beforeExp = String(Array(nStr)[..<exp].filter{ $0 != "." })
 				var afterExp = String(Array(nStr)[(exp + 1)...])
 				var sign = false
-			
+
 				if let neg = afterExp.index(of: "-")?.encodedOffset
 				{
 					afterExp = String(Array(afterExp)[(neg + 1)...])
 					sign = true
 				}
-			
+
 				if sign
 				{
 					let den = ["1"] + [Character](repeating: "0", count: Int(afterExp)!)
@@ -2228,14 +2219,14 @@ public struct BDouble:
 					return
 				}
 			}
-		
+
 			if let io = nStr.index(of: ".")
 			{
 				let i = io.encodedOffset
-			
+
 				let beforePoint = String(Array(nStr)[..<i])
 				let afterPoint  = String(Array(nStr)[(i + 1)...])
-			
+
 				if afterPoint == "0"
 				{
 					self.init(beforePoint, over: "1")
@@ -2260,7 +2251,7 @@ public struct BDouble:
 	public init(_ d: Double)
 	{
 		let nStr = String(d)
-	
+
 		self.init(nStr)!
 	}
 
@@ -2282,14 +2273,14 @@ public struct BDouble:
 	public var fractionDescription : String
 	{
 		var res = (self.sign ? "-" : "")
-	
+
 		res.append(self.numerator.decimalRepresentation)
-	
+
 		if self.denominator != [1]
 		{
 			res.append("/".appending(self.denominator.decimalRepresentation))
 		}
-	
+
 		return res
 	}
 
@@ -2315,18 +2306,19 @@ public struct BDouble:
 	public func decimalExpansion(precisionAfterComma digits: Int) -> String
 	{
 		let multiplier = [10].exponentiating(digits)
-	
+
 		let rawRes = numerator.multiplyingBy(multiplier).divMod(denominator).quotient
-	
+
 		var res = BInt(limbs: rawRes).description
-	
+
 		if digits > 0
 		{
 			res.insert(".", at: String.Index(encodedOffset: res.count - digits))
 		}
-	
+
 		return res
 	}
+
 	public var hashValue: Int
 	{
 		return "\(self.sign)\(self.numerator)\(self.denominator)".hashValue
@@ -2356,9 +2348,9 @@ public struct BDouble:
 			self.denominator = [1]
 			return
 		}
-	
+
 		let gcd = BIntMath.euclid(self.numerator, self.denominator)
-	
+
 		if gcd[0] > 1 || gcd.count > 1
 		{
 			self.numerator = self.numerator.divMod(gcd).quotient
@@ -2402,10 +2394,16 @@ public func ==(lhs: BDouble, rhs: BDouble) -> Bool
 
 	return true
 }
+public func ==(lhs: BDouble, rhs: Double) -> Bool { return lhs == BDouble(rhs) }
+public func ==(lhs: Double, rhs: BDouble) -> Bool { return BDouble(lhs) == rhs }
+
 public func !=(lhs: BDouble, rhs: BDouble) -> Bool
 {
 	return !(lhs == rhs)
 }
+public func !=(lhs: BDouble, rhs: Double) -> Bool { return lhs != BDouble(rhs) }
+public func !=(lhs: Double, rhs: BDouble) -> Bool { return BDouble(lhs) != rhs }
+
 public func <(lhs: BDouble, rhs: BDouble) -> Bool
 {
 	if lhs.sign != rhs.sign { return lhs.sign }
@@ -2418,9 +2416,21 @@ public func <(lhs: BDouble, rhs: BDouble) -> Bool
 
 	return ad.lessThan(bc)
 }
-public func  >(lhs: BDouble, rhs: BDouble) -> Bool { return rhs < lhs }
+public func <(lhs: BDouble, rhs: Double) -> Bool { return lhs < BDouble(rhs) }
+public func <(lhs: Double, rhs: BDouble) -> Bool { return BDouble(lhs) < rhs }
+
+public func >(lhs: BDouble, rhs: BDouble) -> Bool { return rhs < lhs }
+public func >(lhs: BDouble, rhs: Double) -> Bool { return lhs > BDouble(rhs) }
+public func >(lhs: Double, rhs: BDouble) -> Bool { return BDouble(lhs) > rhs }
+
 public func <=(lhs: BDouble, rhs: BDouble) -> Bool { return !(rhs < lhs) }
+public func <=(lhs: BDouble, rhs: Double) -> Bool { return lhs <= BDouble(rhs) }
+public func <=(lhs: Double, rhs: BDouble) -> Bool { return BDouble(lhs) <= rhs }
+
 public func >=(lhs: BDouble, rhs: BDouble) -> Bool { return !(lhs < rhs) }
+public func >=(lhs: BDouble, rhs: Double) -> Bool { return lhs >= BDouble(rhs) }
+public func >=(lhs: Double, rhs: BDouble) -> Bool { return BDouble(lhs) >= rhs }
+
 public func *(lhs: BDouble, rhs: BDouble) -> BDouble
 {
 	var res =  BDouble(
@@ -2432,6 +2442,9 @@ public func *(lhs: BDouble, rhs: BDouble) -> BDouble
 	if res.isZero() { res.sign = false }
 	return res
 }
+public func *(lhs: BDouble, rhs: Double) -> BDouble { return lhs * BDouble(rhs) }
+public func *(lhs: Double, rhs: BDouble) -> BDouble { return BDouble(lhs) * rhs }
+
 public func /(lhs: BDouble, rhs: BDouble) -> BDouble
 {
 	var res =  BDouble(
@@ -2443,6 +2456,9 @@ public func /(lhs: BDouble, rhs: BDouble) -> BDouble
 	if res.isZero() { res.sign = false }
 	return res
 }
+public func /(lhs: BDouble, rhs: Double) -> BDouble { return lhs / BDouble(rhs) }
+public func /(lhs: Double, rhs: BDouble) -> BDouble { return BDouble(lhs) / rhs }
+
 public func +(lhs: BDouble, rhs: BDouble) -> BDouble
 {
 	let ad = lhs.numerator.multiplyingBy(rhs.denominator)
@@ -2457,6 +2473,9 @@ public func +(lhs: BDouble, rhs: BDouble) -> BDouble
 		denominator: bd
 	)
 }
+public func +(lhs: BDouble, rhs: Double) -> BDouble { return lhs + BDouble(rhs) }
+public func +(lhs: Double, rhs: BDouble) -> BDouble { return BDouble(lhs) + rhs }
+
 public prefix func -(n: BDouble) -> BDouble
 {
 	var n = n
@@ -2467,6 +2486,9 @@ public func -(lhs: BDouble, rhs: BDouble) -> BDouble
 {
 	return lhs + -rhs
 }
+public func -(lhs: BDouble, rhs: Double) -> BDouble { return lhs - BDouble(rhs) }
+public func -(lhs: Double, rhs: BDouble) -> BDouble { return BDouble(lhs) - rhs }
+
 public func abs(_ lhs: BDouble) -> BDouble
 {
 	return BDouble(

--- a/Sources/SMP.swift
+++ b/Sources/SMP.swift
@@ -95,49 +95,38 @@
 //	Maximum line length: 96 characters
 //
 //	————————————————————————————————————————————————————————————————————————————————————————————
-
-
-
 //	MARK: - Imports
 //	————————————————————————————————————————————————————————————————————————————————————————————
 //	||||||||        Imports        |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 //	————————————————————————————————————————————————————————————————————————————————————————————
-
 import Foundation
-
 //	MARK: - Typealiases
 //	————————————————————————————————————————————————————————————————————————————————————————————
 //	||||||||        Typealiases        |||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 //	————————————————————————————————————————————————————————————————————————————————————————————
-
 //	Limbs are basically single Digits in base 2^64. Each slot in an Limbs array stores one
 //	Digit of the number. The least significant digit is stored at index 0, the most significant
 //	digit is stored at the last index.
 public typealias Limbs  = [UInt64]
 public typealias Limb   =  UInt64
-
 //	A digit is a number in base 10^18. This is the biggest possible base that
 //	fits into an unsigned 64 bit number while maintaining the propery that the square root of
 //	the base is a whole number and a power of ten . Digits are required for printing BInt
 //	numbers. Limbs are converted into Digits first, and then printed.
 public typealias Digits = [UInt64]
 public typealias Digit  =  UInt64
-
 //	MARK: - Imports
 //	————————————————————————————————————————————————————————————————————————————————————————————
 //	||||||||        Operators        |||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 //	————————————————————————————————————————————————————————————————————————————————————————————
-
 precedencegroup ExponentiationPrecedence
 {
 	associativity: left
 	higherThan: MultiplicationPrecedence
 	lowerThan: BitwiseShiftPrecedence
 }
-
 // Exponentiation operator
 infix operator ** : ExponentiationPrecedence
-
 //	MARK: - BInt
 //	————————————————————————————————————————————————————————————————————————————————————————————
 //	||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
@@ -146,7 +135,6 @@ infix operator ** : ExponentiationPrecedence
 //	||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 //	||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||||
 //	————————————————————————————————————————————————————————————————————————————————————————————
-
 ///	BInt is an arbitrary precision integer value type. It stores a number in base 2^64 notation
 ///	as an array. Each element of the array is called a limb, which is of type UInt64, the whole
 ///	array is called limbs and has the type [UInt64]. A boolean sign variable determines if the
@@ -255,21 +243,21 @@ public struct BInt:
 	}
 
 	/// Create an instance initialized to a string value.
-	public init(_ str: String)
+	public init?(_ str: String)
 	{
 		var str = str
 		var sign = false
 		var base: Limbs = [1]
 		var limbs: Limbs = [0]
-
+	
 		limbs.reserveCapacity(Int(Double(str.count) / log10(pow(2.0, 64.0))))
-
+	
 		if str.hasPrefix("-")
 		{
 			str.remove(at: str.startIndex)
 			sign = str != "0"
 		}
-
+	
 		for chunk in String(str.reversed()).split(19).map({ String($0.reversed()) })
 		{
 			if let num = Limb(String(chunk))
@@ -279,10 +267,10 @@ public struct BInt:
 			}
 			else
 			{
-				fatalError("Error: String must only consist of Digits (0-9)")
+				return nil
 			}
 		}
-
+	
 		self.init(sign: sign, limbs: limbs)
 	}
 
@@ -351,7 +339,7 @@ public struct BInt:
 		return (self.sign ? "-" : "").appending(self.limbs.decimalRepresentation)
 	}
 
-	public init(number: String, withBase base: Int)
+	public init?(number: String, withBase base: Int)
 	{
 		self.init(number.convertingBase(from: base, toBase: 10))
 	}
@@ -360,7 +348,7 @@ public struct BInt:
 	{
 		let str = self.limbs.decimalRepresentation
 		let newStr = str.convertingBase(from: 10, toBase: base)
-
+	
 		if self.sign { return "-".appending(newStr) }
 		return newStr
 	}
@@ -380,23 +368,23 @@ public struct BInt:
 	{
 		//	Conversion only works when self has only one limb thats smaller or
 		//	equal to abs(Int.min).
-
+	
 		if self.limbs.count != 1 { return nil }
-
+	
 		let number = self.limbs[0]
-
+	
 		//	Self is within the range of Int
 		if number <= Limb(Int.max)
 		{
 			return self.sign ? -Int(number) : Int(number)
 		}
-
+	
 		//	Special case: self == Int.min
 		if number == (Limb(Int.max) + 1) && self.sign
 		{
 			return Int.min
 		}
-
+	
 		return nil
 	}
 
@@ -462,10 +450,10 @@ public struct BInt:
 	public static func <<<T: BinaryInteger>(lhs: BInt, rhs: T) -> BInt
 	{
 		if rhs < 0 { return lhs >> rhs }
-
+	
 		let limbs = lhs.limbs.shiftingUp(Int(rhs))
 		let sign = lhs.isNegative() && !limbs.equalTo(0)
-
+	
 		return BInt(sign: sign, limbs: limbs)
 	}
 
@@ -499,19 +487,19 @@ public struct BInt:
 	public static func &(lhs: BInt, rhs: BInt) -> BInt
 	{
 		var res: Limbs = [0]
-
+	
 		for i in 0..<(64 * Swift.max(lhs.limbs.count, rhs.limbs.count))
 		{
 			let newBit = lhs.limbs.getBit(at: i) && lhs.limbs.getBit(at: i)
 			res.setBit(at: i, to: newBit)
 		}
-
+	
 		return BInt(sign: lhs.sign && rhs.sign, limbs: res)
 	}
 
 
-//	static func &(lhs: Int, rhs: BInt) -> BInt
-//	static func &(lhs: BInt, rhs: Int) -> BInt
+	//	static func &(lhs: Int, rhs: BInt) -> BInt
+	//	static func &(lhs: BInt, rhs: Int) -> BInt
 
 	///	Stores the result of performing a bitwise AND operation on the two given values in the
 	///	left-hand-side variable.
@@ -521,8 +509,8 @@ public struct BInt:
 		lhs = res
 	}
 
-//	static func &=(inout lhs: Int, rhs: BInt)
-//	static func &=(inout lhs: BInt, rhs: Int)
+	//	static func &=(inout lhs: Int, rhs: BInt)
+	//	static func &=(inout lhs: BInt, rhs: Int)
 
 	//
 	//
@@ -537,13 +525,13 @@ public struct BInt:
 	public static func |(lhs: BInt, rhs: BInt) -> BInt
 	{
 		var res: Limbs = [0]
-
+	
 		for i in 0..<(64 * Swift.max(lhs.limbs.count, rhs.limbs.count))
 		{
 			let newBit = lhs.limbs.getBit(at: i) || lhs.limbs.getBit(at: i)
 			res.setBit(at: i, to: newBit)
 		}
-
+	
 		return BInt(sign: lhs.sign || rhs.sign, limbs: res)
 	}
 
@@ -571,13 +559,13 @@ public struct BInt:
 	public static func ^(lhs: BInt, rhs: BInt) -> BInt
 	{
 		var res: Limbs = [0]
-
+	
 		for i in 0..<(64 * Swift.max(lhs.limbs.count, rhs.limbs.count))
 		{
 			let newBit = lhs.limbs.getBit(at: i) != lhs.limbs.getBit(at: i)
 			res.setBit(at: i, to: newBit)
 		}
-
+	
 		return BInt(sign: lhs.sign != rhs.sign, limbs: res)
 	}
 
@@ -604,9 +592,9 @@ public struct BInt:
 		{
 			res.setBit(at: i, to: !res.getBit(at: i))
 		}
-
+	
 		while res.last! == 0 && res.count > 1 { res.removeLast() }
-
+	
 		return BInt(sign: !x.sign, limbs: res)
 	}
 
@@ -633,11 +621,11 @@ public struct BInt:
 			lhs.limbs.addLimbs(rhs.limbs)
 			return
 		}
-
+	
 		let rhsIsMin = rhs.limbs.lessThan(lhs.limbs)
 		lhs.limbs.difference(rhs.limbs)
 		lhs.sign = (rhs.sign && !rhsIsMin) || (lhs.sign && rhsIsMin) // DNF minimization
-
+	
 		if lhs.isZero() { lhs.sign = false }
 	}
 
@@ -747,7 +735,7 @@ public struct BInt:
 	func factorial() -> BInt
 	{
 		precondition(!self.sign, "Can't calculate the factorial of an negative number")
-
+	
 		return BInt(limbs: Limbs.recursiveMul(0, Limb(self.toInt()!)))
 	}
 
@@ -772,7 +760,7 @@ public struct BInt:
 	{
 		let limbs = lhs.limbs.divMod(rhs.limbs).quotient
 		let sign = (lhs.sign != rhs.sign) && !limbs.equalTo(0)
-
+	
 		return BInt(sign: sign, limbs: limbs)
 	}
 
@@ -796,7 +784,7 @@ public struct BInt:
 	{
 		let limbs = lhs.limbs.divMod(rhs.limbs).remainder
 		let sign = lhs.sign && !limbs.equalTo(0)
-
+	
 		return BInt(sign: sign, limbs: limbs)
 	}
 
@@ -851,7 +839,7 @@ public struct BInt:
 	public static func <(lhs: BInt, rhs: BInt) -> Bool
 	{
 		if lhs.sign != rhs.sign { return lhs.sign }
-
+	
 		if lhs.sign { return rhs.limbs.lessThan(lhs.limbs) }
 		return lhs.limbs.lessThan(rhs.limbs)
 	}
@@ -859,7 +847,7 @@ public struct BInt:
 	static func <<T: BinaryInteger>(lhs: BInt, rhs: T) -> Bool
 	{
 		if lhs.sign != (rhs < 0) { return lhs.sign }
-
+	
 		if lhs.sign
 		{
 			if lhs.limbs.count != 1 { return true }
@@ -870,7 +858,7 @@ public struct BInt:
 			if lhs.limbs.count != 1 { return false }
 			return lhs.limbs[0] < rhs
 		}
-
+	
 	}
 
 	static func <(lhs:  Int, rhs: BInt) -> Bool { return BInt(lhs) < rhs }
@@ -891,7 +879,6 @@ public struct BInt:
 	static func >=(lhs:  Int, rhs: BInt) -> Bool { return !(BInt(lhs) < rhs) }
 	static func >=(lhs: BInt, rhs:  Int) -> Bool { return !(lhs < BInt(rhs)) }
 }
-
 //
 //
 //	MARK: - String operations
@@ -905,7 +892,6 @@ public struct BInt:
 //
 //
 //
-
 fileprivate extension String
 {
 	// Splits the string into equally sized parts (exept for the last one).
@@ -929,25 +915,25 @@ fileprivate extension String
 			"M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X",
 			"Y", "Z"
 		]
-
+	
 		var res = ""
 		var number = self
-
+	
 		if number.hasPrefix("-")
 		{
 			res = "-"
 			number.removeFirst()
 		}
-
+	
 		var sum = BInt(0)
 		var multiplier = BInt(1)
-
+	
 		for char in number.reversed()
 		{
 			if let digit = chars.index(of: char)
 			{
 				precondition(digit < from)
-
+			
 				sum += digit * multiplier
 				multiplier *= from
 			}
@@ -956,23 +942,20 @@ fileprivate extension String
 				fatalError()
 			}
 		}
-
+	
 		repeat
 		{
 			res.insert(chars[(sum % toBase).toInt()!], at: res.startIndex)
 			sum /= BInt(toBase)
 		}
 			while sum != 0
-
+	
 		return res
 	}
 }
-
 fileprivate let DigitBase:     Digit = 1_000_000_000_000_000_000
 fileprivate let DigitHalfBase: Digit =             1_000_000_000
 fileprivate let DigitZeros           =                        18
-
-
 fileprivate extension Array where Element == Limb
 {
 	var decimalRepresentation: String
@@ -980,38 +963,37 @@ fileprivate extension Array where Element == Limb
 		// First, convert limbs to digits
 		var digits: Digits = [0]
 		var power: Digits = [1]
-
+	
 		for limb in self
 		{
 			let digit = (limb >= DigitBase)
 				? [limb % DigitBase, limb / DigitBase]
 				: [limb]
-
+		
 			digits.addProductOfDigits(digit, power)
-
+		
 			var nextPower: Digits = [0]
 			nextPower.addProductOfDigits(power, [446_744_073_709_551_616, 18])
 			power = nextPower
 		}
-
+	
 		// Then, convert digits to string
 		var res = String(digits.last!)
-
+	
 		if digits.count == 1 { return res }
-
+	
 		for i in (0..<(digits.count - 1)).reversed()
 		{
 			let str = String(digits[i])
-
+		
 			let leadingZeros = String(repeating: "0", count: DigitZeros - str.count)
-
+		
 			res.append(leadingZeros.appending(str))
 		}
-
+	
 		return res
 	}
 }
-
 fileprivate extension Digit
 {
 	mutating func addReportingOverflowDigit(_ addend: Digit) -> Bool
@@ -1025,38 +1007,37 @@ fileprivate extension Digit
 	{
 		let (lLo, lHi) = (self % DigitHalfBase, self / DigitHalfBase)
 		let (rLo, rHi) = (multiplicand % DigitHalfBase, multiplicand / DigitHalfBase)
-
+	
 		let K = (lHi * rLo) + (rHi * lLo)
-
+	
 		var resLo = (lLo * rLo) + ((K % DigitHalfBase) * DigitHalfBase)
 		var resHi = (lHi * rHi) + (K / DigitHalfBase)
-
+	
 		if resLo >= DigitBase
 		{
 			resLo -= DigitBase
 			resHi += 1
 		}
-
+	
 		return (resLo, resHi)
 	}
 }
-
 fileprivate extension Array where Element == Digit
 {
 	mutating func addOneDigit(
 		_ addend: Limb,
 		padding paddingZeros: Int
-	){
+		){
 		let sc = self.count
-
+	
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self.append(addend); return }
-
+	
 		// Now, i < sc
 		var i = paddingZeros
-
+	
 		let ovfl = self[i].addReportingOverflowDigit(addend)
-
+	
 		while ovfl
 		{
 			i += 1
@@ -1073,17 +1054,17 @@ fileprivate extension Array where Element == Digit
 		padding paddingZeros: Int)
 	{
 		let sc = self.count
-
+	
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self += [addendLow, addendHigh]; return }
-
+	
 		// Now, i < sc
 		var i = paddingZeros
 		var newDigit: Digit
-
+	
 		let ovfl1 = self[i].addReportingOverflowDigit(addendLow)
 		i += 1
-
+	
 		if i == sc
 		{
 			newDigit = (addendHigh &+ (ovfl1 ? 1 : 0)) % DigitBase
@@ -1091,7 +1072,7 @@ fileprivate extension Array where Element == Digit
 			if newDigit == 0 { self.append(1) }
 			return
 		}
-
+	
 		// Still, i < sc
 		var ovfl2 = self[i].addReportingOverflowDigit(addendHigh)
 		if ovfl1
@@ -1099,7 +1080,7 @@ fileprivate extension Array where Element == Digit
 			self[i] += 1
 			if self[i] == DigitBase { self[i] = 0; ovfl2 = true }
 		}
-
+	
 		while ovfl2
 		{
 			i += 1
@@ -1114,21 +1095,21 @@ fileprivate extension Array where Element == Digit
 	{
 		let (mpc, mcc) = (multiplier.count, multiplicand.count)
 		self.reserveCapacity(mpc &+ mcc)
-
+	
 		var l, r, resLo, resHi: Digit
-
+	
 		for i in 0..<mpc
 		{
 			l = multiplier[i]
 			if l == 0 { continue }
-
+		
 			for j in 0..<mcc
 			{
 				r = multiplicand[j]
 				if r == 0 { continue }
-
+			
 				(resLo, resHi) = l.multipliedFullWidthDigit(by: r)
-
+			
 				if resHi == 0
 				{
 					self.addOneDigit(resLo, padding: i + j)
@@ -1141,10 +1122,6 @@ fileprivate extension Array where Element == Digit
 		}
 	}
 }
-
-
-
-
 //
 //
 //	MARK: - Limbs extension
@@ -1158,7 +1135,6 @@ fileprivate extension Array where Element == Digit
 //
 //
 //
-
 // Extension to Limbs type
 fileprivate extension Array where Element == Limb
 {
@@ -1178,12 +1154,12 @@ fileprivate extension Array where Element == Limb
 	{
 		var lastBits = 0
 		var last = self.last!
-
+	
 		while last != 0 {
 			last >>= 1
 			lastBits += 1
 		}
-
+	
 		return ((self.count - 1) * 64) + lastBits
 	}
 
@@ -1191,11 +1167,11 @@ fileprivate extension Array where Element == Limb
 	func getBit(at i: Int) -> Bool
 	{
 		let limbIndex = Int(Limb(i) >> 6)
-
+	
 		if limbIndex >= self.count { return false }
-
+	
 		let bitIndex = Limb(i) & 0b111_111
-
+	
 		return (self[limbIndex] & (1 << bitIndex)) != 0
 	}
 
@@ -1203,15 +1179,15 @@ fileprivate extension Array where Element == Limb
 	mutating func setBit(
 		at i: Int,
 		to bit: Bool
-	){
+		){
 		let limbIndex = Int(Limb(i) >> 6)
-
+	
 		if limbIndex >= self.count && !bit { return }
-
+	
 		let bitIndex = Limb(i) & 0b111_111
-
+	
 		while limbIndex >= self.count { self.append(0) }
-
+	
 		if bit
 		{
 			self[limbIndex] |= (1 << bitIndex)
@@ -1236,32 +1212,32 @@ fileprivate extension Array where Element == Limb
 	{
 		// No shifting is required in this case
 		if shift == 0 || self.equalTo(0) { return }
-
+	
 		let limbShifts =  shift >> 6
 		let bitShifts = Limb(shift) & 0x3f
-
+	
 		if bitShifts != 0
 		{
 			var previousCarry = Limb(0)
 			var carry = Limb(0)
 			var ele = Limb(0) // use variable to minimize array accesses
-
+		
 			for i in 0..<self.count
 			{
 				ele = self[i]
-
+			
 				carry = ele >> (64 - bitShifts)
-
+			
 				ele <<= bitShifts
 				ele |= previousCarry // carry from last step
 				previousCarry = carry
-
+			
 				self[i] = ele
 			}
-
+		
 			if previousCarry != 0 { self.append(previousCarry) }
 		}
-
+	
 		if limbShifts != 0
 		{
 			self.insert(contentsOf: Limbs(repeating: 0, count: limbShifts), at: 0)
@@ -1278,41 +1254,41 @@ fileprivate extension Array where Element == Limb
 	mutating func shiftDown(_ shift: Int)
 	{
 		if shift == 0 || self.equalTo(0) { return }
-
+	
 		let limbShifts =  shift >> 6
 		let bitShifts = Limb(shift) & 0x3f
-
+	
 		if limbShifts >= self.count
 		{
 			self = [0]
 			return
 		}
-
+	
 		self.removeSubrange(0..<limbShifts)
-
+	
 		if bitShifts != 0
 		{
 			var previousCarry = Limb(0)
 			var carry = Limb(0)
 			var ele = Limb(0) // use variable to minimize array accesses
-
+		
 			var i = self.count - 1 // use while for high performance
 			while i >= 0
 			{
 				ele = self[i]
-
+			
 				carry = ele << (64 - bitShifts)
-
+			
 				ele >>= bitShifts
 				ele |= previousCarry
 				previousCarry = carry
-
+			
 				self[i] = ele
-
+			
 				i -= 1
 			}
 		}
-
+	
 		if self.last! == 0 && self.count != 1 { self.removeLast() }
 	}
 
@@ -1336,11 +1312,11 @@ fileprivate extension Array where Element == Limb
 	mutating func addLimbs(_ addend: Limbs)
 	{
 		let (sc, ac) = (self.count, addend.count)
-
+	
 		var (newLimb, ovfl) = (Limb(0), false)
-
+	
 		let minCount = Swift.min(sc, ac)
-
+	
 		var i = 0
 		while i < minCount
 		{
@@ -1348,18 +1324,18 @@ fileprivate extension Array where Element == Limb
 			{
 				(newLimb, ovfl) =  self[i].addingReportingOverflow(addend[i])
 				newLimb = newLimb &+ 1
-
+			
 				ovfl = ovfl || newLimb == 0
 			}
 			else
 			{
 				(newLimb, ovfl) = self[i].addingReportingOverflow(addend[i])
 			}
-
+		
 			self[i] = newLimb
 			i += 1
 		}
-
+	
 		while ovfl
 		{
 			if i < sc
@@ -1374,7 +1350,7 @@ fileprivate extension Array where Element == Limb
 				{
 					(newLimb, ovfl) = self[i].addingReportingOverflow(1)
 				}
-
+			
 				self[i] = newLimb
 			}
 			else
@@ -1390,10 +1366,10 @@ fileprivate extension Array where Element == Limb
 					return
 				}
 			}
-
+		
 			i += 1
 		}
-
+	
 		if self.count < ac
 		{
 			self.append(contentsOf: addend.suffix(from: i))
@@ -1414,19 +1390,19 @@ fileprivate extension Array where Element == Limb
 	mutating func addLimbs(
 		_ addend: Limbs,
 		padding paddingZeros: Int
-	){
+		){
 		let sc = self.count
-
+	
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self += addend; return }
-
+	
 		// Now, i < sc
 		let ac = addend.count &+ paddingZeros
-
+	
 		var (newLimb, ovfl) = (Limb(0), false)
-
+	
 		let minCount = Swift.min(sc, ac)
-
+	
 		var i = paddingZeros
 		while i < minCount
 		{
@@ -1441,10 +1417,10 @@ fileprivate extension Array where Element == Limb
 			{
 				(self[i], ovfl) = self[i].addingReportingOverflow(addend[i &- paddingZeros])
 			}
-
+		
 			i += 1
 		}
-
+	
 		while ovfl
 		{
 			if i < sc
@@ -1466,10 +1442,10 @@ fileprivate extension Array where Element == Limb
 					return
 				}
 			}
-
+		
 			i += 1
 		}
-
+	
 		if self.count < ac
 		{
 			self.append(contentsOf: addend.suffix(from: i &- paddingZeros))
@@ -1479,18 +1455,18 @@ fileprivate extension Array where Element == Limb
 	mutating func addOneLimb(
 		_ addend: Limb,
 		padding paddingZeros: Int
-	){
+		){
 		let sc = self.count
-
+	
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self.append(addend); return }
-
+	
 		// Now, i < lhc
 		var i = paddingZeros
-
+	
 		var ovfl: Bool
 		(self[i], ovfl) = self[i].addingReportingOverflow(addend)
-
+	
 		while ovfl
 		{
 			i += 1
@@ -1506,18 +1482,18 @@ fileprivate extension Array where Element == Limb
 		padding paddingZeros: Int)
 	{
 		let sc = self.count
-
+	
 		if paddingZeros >  sc { self += Digits(repeating: 0, count: paddingZeros &- sc) }
 		if paddingZeros >= sc { self += [addendLow, addendHigh]; return }
-
+	
 		// Now, i < sc
 		var i = paddingZeros
 		var newLimb: Limb
-
+	
 		var ovfl1: Bool
 		(self[i], ovfl1) =  self[i].addingReportingOverflow(addendLow)
 		i += 1
-
+	
 		if i == sc
 		{
 			newLimb = addendHigh &+ (ovfl1 ? 1 : 0)
@@ -1525,17 +1501,17 @@ fileprivate extension Array where Element == Limb
 			if newLimb == 0 { self.append(1) }
 			return
 		}
-
+	
 		// Still, i < sc
 		var ovfl2: Bool
 		(self[i], ovfl2) = self[i].addingReportingOverflow(addendHigh)
-
+	
 		if ovfl1
 		{
 			self[i] = self[i] &+ 1
 			if self[i] == 0 { ovfl2 = true }
 		}
-
+	
 		while ovfl2
 		{
 			i += 1
@@ -1560,15 +1536,15 @@ fileprivate extension Array where Element == Limb
 		var subtrahend = subtrahend
 		// swap to get difference
 		if self.lessThan(subtrahend) { swap(&self, &subtrahend) }
-
+	
 		let rhc = subtrahend.count
 		var ovfl = false
-
+	
 		var i = 0
-
+	
 		// skip first zeros
 		while i < rhc && subtrahend[i] == 0 { i += 1 }
-
+	
 		while i < rhc
 		{
 			if ovfl
@@ -1581,10 +1557,10 @@ fileprivate extension Array where Element == Limb
 			{
 				(self[i], ovfl) = self[i].subtractingReportingOverflow(subtrahend[i])
 			}
-
+		
 			i += 1
 		}
-
+	
 		while ovfl
 		{
 			if i >= self.count
@@ -1592,17 +1568,17 @@ fileprivate extension Array where Element == Limb
 				self.append(Limb.max)
 				break
 			}
-
+		
 			(self[i], ovfl) = self[i].subtractingReportingOverflow(1)
-
+		
 			i += 1
 		}
-
+	
 		if self.count > 1 && self.last! == 0 // cut excess zeros if required
 		{
 			var j = self.count - 2
 			while j >= 1 && self[j] == 0 { j -= 1 }
-
+		
 			self.removeSubrange((j + 1)..<self.count)
 		}
 	}
@@ -1627,26 +1603,26 @@ fileprivate extension Array where Element == Limb
 	mutating func addProductOf(
 		multiplier: Limbs,
 		multiplicand: Limbs
-	){
+		){
 		let (mpc, mcc) = (multiplier.count, multiplicand.count)
-
+	
 		self.reserveCapacity(mpc + mcc)
-
+	
 		// Minimize array subscript calls
 		var l, r, mulHi, mulLo: Limb
-
+	
 		for i in 0..<mpc
 		{
 			l = multiplier[i]
 			if l == 0 { continue }
-
+		
 			for j in 0..<mcc
 			{
 				r = multiplicand[j]
 				if r == 0 { continue }
-
+			
 				(mulHi, mulLo) = l.multipliedFullWidth(by: r)
-
+			
 				if mulHi != 0 { self.addTwoLimb(mulLo, mulHi, padding: i + j) }
 				else          { self.addOneLimb(mulLo,        padding: i + j) }
 			}
@@ -1657,24 +1633,24 @@ fileprivate extension Array where Element == Limb
 	mutating func addProductOf(
 		multiplier: Limbs,
 		multiplicand: Limb
-	){
+		){
 		if multiplicand < 2
 		{
 			if multiplicand == 1 { self.addLimbs(multiplier) }
 			// If r == 0 then do nothing with res
 			return
 		}
-
+	
 		// Minimize array subscript calls
 		var l, mulHi, mulLo: Limb
-
+	
 		for i in 0..<multiplier.count
 		{
 			l = multiplier[i]
 			if l == 0 { continue }
-
+		
 			(mulHi, mulLo) = l.multipliedFullWidth(by: multiplicand)
-
+		
 			if mulHi != 0 { self.addTwoLimb(mulLo, mulHi, padding: i) }
 			else {          self.addOneLimb(mulLo,        padding: i) }
 		}
@@ -1691,22 +1667,22 @@ fileprivate extension Array where Element == Limb
 	{
 		var res: Limbs = [0]
 		res.reserveCapacity(2 * self.count)
-
+	
 		// Minimize array subscript calls
 		var l, r, mulHi, mulLo: Limb
-
+	
 		for i in 0..<self.count
 		{
 			l = self[i]
 			if l == 0 { continue }
-
+		
 			for j in 0...i
 			{
 				r = self[j]
 				if r == 0 { continue }
-
+			
 				(mulHi, mulLo) = l.multipliedFullWidth(by: r)
-
+			
 				if mulHi != 0
 				{
 					if i != j { res.addTwoLimb(mulLo, mulHi, padding: i + j) }
@@ -1719,7 +1695,7 @@ fileprivate extension Array where Element == Limb
 				}
 			}
 		}
-
+	
 		return res
 	}
 
@@ -1738,18 +1714,18 @@ fileprivate extension Array where Element == Limb
 	{
 		if exponent == 0 { return [1] }
 		if exponent == 1 { return self }
-
+	
 		var base = self
 		var exponent = exponent
 		var y: Limbs = [1]
-
+	
 		while exponent > 1
 		{
 			if exponent & 1 != 0 { y = y.multiplyingBy(base) }
 			base = base.squared()
 			exponent >>= 1
 		}
-
+	
 		return base.multiplyingBy(y)
 	}
 
@@ -1757,9 +1733,9 @@ fileprivate extension Array where Element == Limb
 	static func recursiveMul(_ n: Limb, _ k: Limb) -> Limbs
 	{
 		if n >= k - 1 { return [k] }
-
+	
 		let m = (n + k) >> 1
-
+	
 		return recursiveMul(n, m).multiplyingBy(recursiveMul(m, k))
 	}
 
@@ -1782,15 +1758,15 @@ fileprivate extension Array where Element == Limb
 	func divMod(_ divisor: Limbs) -> (quotient: Limbs, remainder: Limbs)
 	{
 		precondition(!divisor.equalTo(0), "Division or Modulo by zero not allowed")
-
+	
 		if self.equalTo(0) { return ([0], [0]) }
-
+	
 		var (quotient, remainder): (Limbs, Limbs) = ([0], [0])
 		var (previousCarry, carry, ele): (Limb, Limb, Limb) = (0, 0, 0)
-
+	
 		// bits of lhs minus one bit
 		var i = (64 * (self.count - 1)) + Int(log2(Double(self.last!)))
-
+	
 		while i >= 0
 		{
 			// shift remainder by 1 to the left
@@ -1804,18 +1780,18 @@ fileprivate extension Array where Element == Limb
 				remainder[r] = ele
 			}
 			if previousCarry != 0 { remainder.append(previousCarry) }
-
+		
 			remainder.setBit(at: 0, to: self.getBit(at: i))
-
+		
 			if !remainder.lessThan(divisor)
 			{
 				remainder.difference(divisor)
 				quotient.setBit(at: i, to: true)
 			}
-
+		
 			i -= 1
 		}
-
+	
 		return (quotient, remainder)
 	}
 
@@ -1852,19 +1828,19 @@ fileprivate extension Array where Element == Limb
 	{
 		let lhsc = self.count
 		let rhsc = compare.count
-
+	
 		if lhsc != rhsc
 		{
 			return lhsc < rhsc
 		}
-
+	
 		var i = lhsc - 1
 		while i >= 0
 		{
 			if self[i] != compare[i] { return self[i] < compare[i] }
 			i -= 1
 		}
-
+	
 		return false // lhs == rhs
 	}
 
@@ -1873,7 +1849,6 @@ fileprivate extension Array where Element == Limb
 		return self[0] == compare && self.count == 1
 	}
 }
-
 //
 //
 //	MARK: - Useful BInt math functions
@@ -1887,26 +1862,25 @@ fileprivate extension Array where Element == Limb
 //
 //
 //
-
 public class BIntMath
 {
 	/// Returns true iff (2 ** exp) - 1 is a mersenne prime.
 	static func isMersenne(_ exp: Int) -> Bool
 	{
 		var mersenne = Limbs(repeating: Limb.max, count: exp >> 6)
-
+	
 		if (exp % 64) > 0
 		{
 			mersenne.append((Limb(1) << Limb(exp % 64)) - Limb(1))
 		}
-
+	
 		var res: Limbs = [4]
-
+	
 		for _ in 0..<(exp - 2)
 		{
 			res = res.squared().differencing([2]).divMod(mersenne).remainder
 		}
-
+	
 		return res.equalTo(0)
 	}
 
@@ -1929,28 +1903,28 @@ public class BIntMath
 	static func steinGcd(_ a: BInt, _ b: BInt) -> BInt
 	{
 		if a.isZero() { return b }
-
+	
 		var (a, b, k) = (a, b, 0)
-
+	
 		while a.isEven() && b.isEven()
 		{
 			a >>= 1
 			b >>= 1
 			k += 1
 		}
-
+	
 		var t = a.isOdd() ? -b : a
-
+	
 		while !t.isZero()
 		{
 			while t.isEven() { t >>= 1 }
-
+		
 			if  t > 0 { a =  t }
 			else      { b = -t }
-
+		
 			t = a - b
 		}
-
+	
 		return a << k
 	}
 
@@ -1973,14 +1947,14 @@ public class BIntMath
 	static func fib(_ n:Int) -> BInt
 	{
 		var a: Limbs = [0], b: Limbs = [1], t: Limbs
-
+	
 		for _ in 2...n
 		{
 			t = b
 			b.addLimbs(a)
 			a = t
 		}
-
+	
 		return BInt(limbs: b)
 	}
 
@@ -1997,7 +1971,7 @@ public class BIntMath
 	{
 		// n ** k
 		return BInt(n) ** k
-
+	
 	}
 
 	///	Order does not matter, repetition not allowed.
@@ -2018,23 +1992,23 @@ public class BIntMath
 	{
 		let limbs = n >> 6
 		let singleBits = n % 64
-
+	
 		var res = Limbs(repeating: 0, count: Int(limbs))
-
+	
 		for i in 0..<Int(limbs)
 		{
 			res[i] = Limb(arc4random_uniform(UInt32.max)) |
 				(Limb(arc4random_uniform(UInt32.max)) << 32)
 		}
-
+	
 		if singleBits > 0
 		{
 			var last: Limb
-
+		
 			if singleBits < 32
 			{
 				last = Limb(arc4random_uniform(UInt32(2 ** singleBits)))
-
+			
 			}
 			else if singleBits == 32
 			{
@@ -2045,19 +2019,19 @@ public class BIntMath
 				last = Limb(arc4random_uniform(UInt32.max)) |
 					(Limb(arc4random_uniform(UInt32(2 ** (singleBits - 32)))) << 32)
 			}
-
+		
 			res.append(last)
 		}
-
+	
 		return BInt(limbs: res)
 	}
 
 	func isPrime(_ n: BInt) -> Bool
 	{
 		if n <= 3 { return n > 1 }
-
+	
 		if ((n % 2) == 0) || ((n % 3) == 0) { return false }
-
+	
 		var i = 5
 		while (i * i) <= n
 		{
@@ -2122,7 +2096,6 @@ public class BIntMath
 		return nnmod(a + b, m)
 	}
 }
-
 //
 //
 //	MARK: - BDouble
@@ -2136,7 +2109,6 @@ public class BIntMath
 //
 //
 //
-
 public struct BDouble:
 	ExpressibleByIntegerLiteral,
 	ExpressibleByFloatLiteral,
@@ -2169,13 +2141,6 @@ public struct BDouble:
 		lhs = res
 	}
 
-
-
-
-
-
-
-
 	var sign = Bool()
 	var numerator = Limbs()
 	var denominator = Limbs()
@@ -2196,11 +2161,11 @@ public struct BDouble:
 			!denominator.equalTo(0) && denominator != [] && numerator != [],
 			"Denominator can't be zero and limbs can't be []"
 		)
-
+	
 		self.sign = sign
 		self.numerator = numerator
 		self.denominator = denominator
-
+	
 		self.minimize()
 	}
 
@@ -2222,14 +2187,69 @@ public struct BDouble:
 		)
 	}
 
-	public init(_ numerator: String, over denominator: String)
+	public init?(_ numerator: String, over denominator: String)
 	{
-		self.init(BInt(numerator), over: BInt(denominator))
+		if let n = BInt(numerator) {
+			if let d = BInt(denominator) {
+				self.init(n, over: d)
+				return
+			}
+		}
+		return nil
 	}
 
-	public init(_ number: String)
+	public init?(_ nStr: String)
 	{
-		self.init(BInt(number), over: BInt(1))
+		if let bi = BInt(nStr) {
+			self.init(bi, over: 1)
+		} else {
+			if let exp = nStr.index(of: "e")?.encodedOffset
+			{
+				let beforeExp = String(Array(nStr)[..<exp].filter{ $0 != "." })
+				var afterExp = String(Array(nStr)[(exp + 1)...])
+				var sign = false
+			
+				if let neg = afterExp.index(of: "-")?.encodedOffset
+				{
+					afterExp = String(Array(afterExp)[(neg + 1)...])
+					sign = true
+				}
+			
+				if sign
+				{
+					let den = ["1"] + [Character](repeating: "0", count: Int(afterExp)!)
+					self.init(beforeExp, over: String(den))
+					return
+				}
+				else
+				{
+					let num = beforeExp + String([Character](repeating: "0", count: Int(afterExp)!))
+					self.init(num, over: "1")
+					return
+				}
+			}
+		
+			if let io = nStr.index(of: ".")
+			{
+				let i = io.encodedOffset
+			
+				let beforePoint = String(Array(nStr)[..<i])
+				let afterPoint  = String(Array(nStr)[(i + 1)...])
+			
+				if afterPoint == "0"
+				{
+					self.init(beforePoint, over: "1")
+				}
+				else
+				{
+					let den = ["1"] + [Character](repeating: "0", count: afterPoint.count)
+					self.init(beforePoint + afterPoint, over: String(den))
+				}
+			} else
+			{
+				return nil
+			}
+		}
 	}
 
 	public init(_ z: Int)
@@ -2240,48 +2260,8 @@ public struct BDouble:
 	public init(_ d: Double)
 	{
 		let nStr = String(d)
-
-		if let exp = nStr.index(of: "e")?.encodedOffset
-		{
-			let beforeExp = String(Array(nStr)[..<exp].filter{ $0 != "." })
-			var afterExp = String(Array(nStr)[(exp + 1)...])
-			var sign = false
-
-			if let neg = afterExp.index(of: "-")?.encodedOffset
-			{
-				afterExp = String(Array(afterExp)[(neg + 1)...])
-				sign = true
-			}
-
-			if sign
-			{
-				let den = ["1"] + [Character](repeating: "0", count: Int(afterExp)!)
-				self.init(beforeExp, over: String(den))
-				return
-			}
-			else
-			{
-				let num = beforeExp + String([Character](repeating: "0", count: Int(afterExp)!))
-				self.init(num, over: "1")
-				return
-			}
-		}
-
-		let i = nStr.index(of: ".")!.encodedOffset
-
-
-		let beforePoint = String(Array(nStr)[..<i])
-		let afterPoint  = String(Array(nStr)[(i + 1)...])
-
-		if afterPoint == "0"
-		{
-			self.init(beforePoint, over: "1")
-		}
-		else
-		{
-			let den = ["1"] + [Character](repeating: "0", count: afterPoint.count)
-			self.init(beforePoint + afterPoint, over: String(den))
-		}
+	
+		self.init(nStr)!
 	}
 
 	public init(integerLiteral value: Int)
@@ -2296,34 +2276,57 @@ public struct BDouble:
 
 	public var description: String
 	{
+		return self.fractionDescription
+	}
+
+	public var fractionDescription : String
+	{
 		var res = (self.sign ? "-" : "")
-
+	
 		res.append(self.numerator.decimalRepresentation)
-
+	
 		if self.denominator != [1]
 		{
 			res.append("/".appending(self.denominator.decimalRepresentation))
 		}
-
+	
 		return res
+	}
+
+	static private var _precision = 4
+	static public var precision : Int
+	{
+		get
+		{
+			return _precision
+		}
+		set
+		{
+			_precision = newValue > 0 ? newValue : 0
+		}
+	}
+	public var precision : Int = BDouble.precision
+
+	public var decimalDescription : String
+	{
+		return self.decimalExpansion(precisionAfterComma: self.precision)
 	}
 
 	public func decimalExpansion(precisionAfterComma digits: Int) -> String
 	{
 		let multiplier = [10].exponentiating(digits)
-
+	
 		let rawRes = numerator.multiplyingBy(multiplier).divMod(denominator).quotient
-
+	
 		var res = BInt(limbs: rawRes).description
-
+	
 		if digits > 0
 		{
 			res.insert(".", at: String.Index(encodedOffset: res.count - digits))
 		}
-
+	
 		return res
 	}
-
 	public var hashValue: Int
 	{
 		return "\(self.sign)\(self.numerator)\(self.denominator)".hashValue
@@ -2353,9 +2356,9 @@ public struct BDouble:
 			self.denominator = [1]
 			return
 		}
-
+	
 		let gcd = BIntMath.euclid(self.numerator, self.denominator)
-
+	
 		if gcd[0] > 1 || gcd.count > 1
 		{
 			self.numerator = self.numerator.divMod(gcd).quotient
@@ -2363,14 +2366,13 @@ public struct BDouble:
 		}
 	}
 
-//	public func sqrt(precision digits: Int) -> BDouble
-//	{
-//		// let self = v
-//		// Find x such that x*x=v <==> x = v/x
-//
-//	}
+	//	public func sqrt(precision digits: Int) -> BDouble
+	//	{
+	//		// let self = v
+	//		// Find x such that x*x=v <==> x = v/x
+	//
+	//	}
 }
-
 /*\
 /**\
 /***\
@@ -2392,8 +2394,6 @@ public struct BDouble:
 \***/
 \**/
 \*/
-
-
 public func ==(lhs: BDouble, rhs: BDouble) -> Bool
 {
 	if lhs.sign != rhs.sign { return false }
@@ -2402,12 +2402,10 @@ public func ==(lhs: BDouble, rhs: BDouble) -> Bool
 
 	return true
 }
-
 public func !=(lhs: BDouble, rhs: BDouble) -> Bool
 {
 	return !(lhs == rhs)
 }
-
 public func <(lhs: BDouble, rhs: BDouble) -> Bool
 {
 	if lhs.sign != rhs.sign { return lhs.sign }
@@ -2420,14 +2418,9 @@ public func <(lhs: BDouble, rhs: BDouble) -> Bool
 
 	return ad.lessThan(bc)
 }
-
 public func  >(lhs: BDouble, rhs: BDouble) -> Bool { return rhs < lhs }
 public func <=(lhs: BDouble, rhs: BDouble) -> Bool { return !(rhs < lhs) }
 public func >=(lhs: BDouble, rhs: BDouble) -> Bool { return !(lhs < rhs) }
-
-
-
-
 public func *(lhs: BDouble, rhs: BDouble) -> BDouble
 {
 	var res =  BDouble(
@@ -2439,7 +2432,6 @@ public func *(lhs: BDouble, rhs: BDouble) -> BDouble
 	if res.isZero() { res.sign = false }
 	return res
 }
-
 public func /(lhs: BDouble, rhs: BDouble) -> BDouble
 {
 	var res =  BDouble(
@@ -2451,9 +2443,6 @@ public func /(lhs: BDouble, rhs: BDouble) -> BDouble
 	if res.isZero() { res.sign = false }
 	return res
 }
-
-
-
 public func +(lhs: BDouble, rhs: BDouble) -> BDouble
 {
 	let ad = lhs.numerator.multiplyingBy(rhs.denominator)
@@ -2468,19 +2457,16 @@ public func +(lhs: BDouble, rhs: BDouble) -> BDouble
 		denominator: bd
 	)
 }
-
 public prefix func -(n: BDouble) -> BDouble
 {
 	var n = n
 	n.negate()
 	return n
 }
-
 public func -(lhs: BDouble, rhs: BDouble) -> BDouble
 {
 	return lhs + -rhs
 }
-
 public func abs(_ lhs: BDouble) -> BDouble
 {
 	return BDouble(


### PR DESCRIPTION
A better String initializer for BDouble for #19. I  just used the initializer for a Double since that was already parsed using its' String representation. 

```
>>> BDouble("no")
nil
>>> BDouble("123")
Optional(123)
>>> BDouble("1.2e10")
Optional(120000000000)
>>> BDouble("1.2")
Optional(6/5)
```

I removed the Fatal Error thrown when constructing an BInt and instead use optionals. I have updated the README to reflect this

I also added more descriptions
```
>>> var bd2 = BDouble("123453434.2341313123123131123123")!
1234534342341313123123131123123/10000000000000000000000
>>> bd2.fractionDescription
1234534342341313123123131123123/10000000000000000000000
>>> bd2.decimalDescription
123453434.2341
>>> bd2.precision = 10
>>> bd2.decimalDescription
123453434.2341313123
>>> bs2.precision = 2
>>> bd2.decimalDescription
123453434.23
```

Can we break up SMP.swift? I love the idea of a single file for usage but my Mac isn't handling it's huge size so well. It won't even show the diff by default on Github

FYSA, you can squash all my commits into one commit to make the repository look cleaner. 

Looking forward to your thoughts. Thanks