### PR TITLE
BDouble test cases and documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,5 @@ Carthage/Build
 
 fastlane/report.xml
 fastlane/screenshots
+
+.DS_Store

--- a/Sources/Info.plist
+++ b/Sources/Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>Copyright © 2017 Marcel Kröker. All rights reserved.</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Sources/SMP.swift
+++ b/Sources/SMP.swift
@@ -2067,6 +2067,7 @@ public class BIntMath
 
 		return BInt(limbs: res)
 	}
+	let random = randomBInt
 
 	func isPrime(_ n: BInt) -> Bool
 	{

--- a/Sources/SMP.swift
+++ b/Sources/SMP.swift
@@ -2059,7 +2059,7 @@ public class BIntMath
 			else
 			{
 				last = Limb(arc4random_uniform(UInt32.max)) |
-					(Limb(arc4random_uniform(UInt32(2 ** (singleBits - 32)))) << 32)
+					(Limb(arc4random_uniform(UInt32(2.0 ** (singleBits - 32)))) << 32)
 			}
 
 			res.append(last)
@@ -2259,15 +2259,21 @@ public struct BDouble:
 
 				if sign
 				{
-					let den = ["1"] + [Character](repeating: "0", count: Int(afterExp)!)
-					self.init(beforeExp, over: String(den))
-					return
+					if let safeAfterExp = Int(afterExp) {
+						let den = ["1"] + [Character](repeating: "0", count: safeAfterExp)
+						self.init(beforeExp, over: String(den))
+						return
+					}
+					return nil
 				}
 				else
 				{
-					let num = beforeExp + String([Character](repeating: "0", count: Int(afterExp)!))
-					self.init(num, over: "1")
-					return
+					if let safeAfterExp = Int(afterExp) {
+						let num = beforeExp + String([Character](repeating: "0", count: safeAfterExp))
+						self.init(num, over: "1")
+						return
+					}
+					return nil
 				}
 			}
 
@@ -2354,10 +2360,29 @@ public struct BDouble:
 		}
 		set
 		{
-			_precision = abs(newValue)
+			var nv = newValue
+			if nv < 0 {
+				nv = 0
+			}
+			_precision = nv
 		}
 	}
-	public var precision : Int = BDouble.precision
+	private var _precision : Int = BDouble.precision
+	public var precision : Int
+	{
+		get
+		{
+			return _precision
+		}
+		set
+		{
+		var nv = newValue
+		if nv < 0 {
+		nv = 0
+		}
+		_precision = nv
+		}
+	}
 
 	public var decimalDescription : String
 	{
@@ -2753,4 +2778,8 @@ public func ceil(_ base: BDouble) -> BInt
 	}
 
 	return retVal
+}
+
+public func pow(_ base : BDouble, _ exp : Int) -> BDouble {
+	return base**exp
 }

--- a/Sources/SMP.swift
+++ b/Sources/SMP.swift
@@ -2391,19 +2391,46 @@ public struct BDouble:
 
 	public func decimalExpansion(precisionAfterComma digits: Int) -> String
 	{
+		if self.isZero() {
+			return "0." + String(repeating: "0", count: max(digits, 1))
+		}
+		
 		let multiplier = [10].exponentiating(digits)
 
-		let rawRes = numerator.multiplyingBy(multiplier).divMod(denominator).quotient
+		let rawRes = abs(self).numerator.multiplyingBy(multiplier).divMod(self.denominator).quotient
 
-		var res = BInt(limbs: rawRes).description
-
-		if digits > 0 && digits < res.count
-		{
+		var res = BInt(limbs: rawRes).description // just the BInt
+		
+		print("before", res)
+		
+		if digits > 0 && digits < res.count {
 			res.insert(".", at: String.Index(encodedOffset: res.count - digits))
 		} else if res.count <= digits {
-			res = "0." + res.padding(toLength: digits, withPad: "0", startingAt: 0)
+			let origRes = res
+			let w = abs(self).numerator.multiplyingBy(multiplier).divMod(self.denominator).remainder
+			res = "0." + String((BInt(limbs: w).description as String).reversed())
+			if res.count < digits + 2
+			{
+				print("adding padding")
+				let pad = String(repeating: "0", count: max(digits, 1))
+				res = res.padding(toLength: digits+2-origRes.count, withPad: pad, startingAt: res.count)
+			}
+			res = res + origRes
+			res = res.prefix(max(3, digits+2)).description
+			print("warning!", res, digits, w)
 		}
-
+		
+		if res == "0"
+		{
+			res = "0." + String(repeating: "0", count: max(digits, 1))
+		}
+		
+		if self.isNegative() {
+			res = "-" + res
+		}
+		
+		print("after", res, self.numerator, self.denominator)
+		
 		return res
 	}
 

--- a/Sources/SMP.swift
+++ b/Sources/SMP.swift
@@ -2397,9 +2397,11 @@ public struct BDouble:
 
 		var res = BInt(limbs: rawRes).description
 
-		if digits > 0
+		if digits > 0 && digits < res.count
 		{
 			res.insert(".", at: String.Index(encodedOffset: res.count - digits))
+		} else if res.count <= digits {
+			res = "0." + res.padding(toLength: digits, withPad: "0", startingAt: 0)
 		}
 
 		return res

--- a/Sources/SMP.swift
+++ b/Sources/SMP.swift
@@ -2333,11 +2333,17 @@ public struct BDouble:
 	//
 	//
 
+	/**
+	 * returns the current value in a fraction format
+	 */
 	public var description: String
 	{
 		return self.fractionDescription
 	}
 
+	/**
+	 * returns the current value in a fraction format
+	 */
 	public var fractionDescription : String
 	{
 		var res = (self.sign ? "-" : "")
@@ -2353,6 +2359,9 @@ public struct BDouble:
 	}
 
 	static private var _precision = 4
+	/**
+	 * the global percision for all newly created values
+	 */
 	static public var precision : Int
 	{
 		get
@@ -2369,6 +2378,10 @@ public struct BDouble:
 		}
 	}
 	private var _precision : Int = BDouble.precision
+	
+	/**
+	 * the precision for the current value
+	 */
 	public var precision : Int
 	{
 		get
@@ -2385,11 +2398,17 @@ public struct BDouble:
 		}
 	}
 
+	/**
+	 * returns the current value in decimal format with the current precision
+	 */
 	public var decimalDescription : String
 	{
 		return self.decimalExpansion(precisionAfterComma: self.precision)
 	}
 
+	/**
+	 * returns the current value in decimal format
+	 */
 	public func decimalExpansion(precisionAfterComma digits: Int) -> String
 	{
 		if self.isZero() {
@@ -2440,14 +2459,17 @@ public struct BDouble:
 		return "\(self.sign)\(self.numerator)\(self.denominator)".hashValue
 	}
 
-	/// Returns the size of the BDouble in bits.
+	/**
+	 * Returns the size of the BDouble in bits.
+     */
 	public var size: Int
 	{
 		return 1 + ((self.numerator.count + self.denominator.count) * 64)
 	}
 
-	/** Returns a formated human readable string that says how much space
-		(in bytes, kilobytes, megabytes, or gigabytes) the BDouble occupies
+	/**
+	 * Returns a formated human readable string that says how much space
+	 * (in bytes, kilobytes, megabytes, or gigabytes) the BDouble occupies
 	*/
 	public var sizeDescription: String
 	{
@@ -2496,7 +2518,8 @@ public struct BDouble:
 	}
 
 	/**
-	 * If the right side of the decimal is greater than 0.5 then it will round up (ceil), otherwise round down (floor) to the nearest BInt
+	 * If the right side of the decimal is greater than 0.5 then it will round up (ceil),
+	 * otherwise round down (floor) to the nearest BInt
 	 */
 	public func rounded() -> BInt
 	{
@@ -2585,6 +2608,9 @@ public struct BDouble:
 	//
 	//
 
+	/**
+	 * makes the current value negative
+	 */
 	public mutating func negate()
 	{
 		if !self.isZero()
@@ -2774,15 +2800,22 @@ public struct BDouble:
 //
 //
 
-public func abs(_ lhs: BDouble) -> BDouble
+/**
+ * Returns the absolute value of the given number.
+* - param x: a big double
+ */
+public func abs(_ x: BDouble) -> BDouble
 {
 	return BDouble(
 		sign: false,
-		numerator: lhs.numerator,
-		denominator: lhs.denominator
+		numerator: x.numerator,
+		denominator: x.denominator
 	)
 }
 
+/**
+ * round to largest BInt value not greater than base
+ */
 public func floor(_ base: BDouble) -> BInt
 {
 	if base.isZero()
@@ -2808,9 +2841,13 @@ public func floor(_ base: BDouble) -> BInt
 			ans = ans - BInt(1)
 		}
 	}
+	
 	return ans
 }
 
+/**
+ * round to smallest BInt value not less than base
+ */
 public func ceil(_ base: BDouble) -> BInt
 {
 	if base.isZero()
@@ -2843,6 +2880,9 @@ public func ceil(_ base: BDouble) -> BInt
 	return retVal
 }
 
+/**
+ * Returns a BDouble number raised to a given power.
+ */
 public func pow(_ base : BDouble, _ exp : Int) -> BDouble {
 	return base**exp
 }

--- a/Sources/SMP.swift
+++ b/Sources/SMP.swift
@@ -2802,7 +2802,7 @@ public struct BDouble:
 
 /**
  * Returns the absolute value of the given number.
-* - param x: a big double
+ * - parameter x: a big double
  */
 public func abs(_ x: BDouble) -> BDouble
 {
@@ -2841,7 +2841,7 @@ public func floor(_ base: BDouble) -> BInt
 			ans = ans - BInt(1)
 		}
 	}
-	
+
 	return ans
 }
 

--- a/Sources/SMP.swift
+++ b/Sources/SMP.swift
@@ -2467,6 +2467,9 @@ public struct BDouble:
 		}
 	}
 
+	/**
+	 * If the right side of the decimal is greater than 0.5 then it will round up (ceil), otherwise round down (floor) to the nearest BInt
+	 */
 	public func rounded() -> BInt
 	{
 		if self.isZero() {
@@ -2475,17 +2478,26 @@ public struct BDouble:
 		let digits = 3
 		let multiplier = [10].exponentiating(digits)
 
-		let rawRes = self.numerator.multiplyingBy(multiplier).divMod(self.denominator).quotient
+		let rawRes = abs(self).numerator.multiplyingBy(multiplier).divMod(self.denominator).quotient
 
 		let res = BInt(limbs: rawRes).description
 
 		let offset = res.count - digits
-		let rhs = Double("0." + res.suffix(offset+1))!
+		let rhs = Double("0." + res.suffix(res.count - offset))!
 		let lhs = res.prefix(offset)
 		var retVal = BInt(String(lhs))!
-		if rhs > 0.5
+		
+		if self.isNegative()
 		{
-			retVal = retVal + 1
+			retVal = -retVal
+			if rhs > 0.5 {
+				retVal = retVal - BInt(1)
+			}
+		} else {
+			if rhs > 0.5
+			{
+				retVal = retVal + 1
+			}
 		}
 
 		return retVal
@@ -2745,40 +2757,61 @@ public func abs(_ lhs: BDouble) -> BDouble
 
 public func floor(_ base: BDouble) -> BInt
 {
+	if base.isZero()
+	{
+		return BInt(0)
+	}
+	
 	let digits = 3
 	let multiplier = [10].exponentiating(digits)
 
-	let rawRes = base.numerator.multiplyingBy(multiplier).divMod(base.denominator).quotient
+	let rawRes = abs(base).numerator.multiplyingBy(multiplier).divMod(base.denominator).quotient
 
 	let res = BInt(limbs: rawRes).description
-
+	
 	let offset = res.count - digits
-	let lhs = res.prefix(offset)
-
-	return BInt(String(lhs))!
+	let lhs = res.prefix(offset).description
+	let rhs = Double("0." + res.suffix(res.count - offset))!
+	
+	var ans = BInt(String(lhs))!
+	if base.isNegative() {
+		ans = -ans
+		if rhs > 0.0 {
+			ans = ans - BInt(1)
+		}
+	}
+	return ans
 }
 
 public func ceil(_ base: BDouble) -> BInt
 {
-	if base.isZero() {
+	if base.isZero()
+	{
 		return BInt(0)
 	}
 	let digits = 3
 	let multiplier = [10].exponentiating(digits)
 
-	let rawRes = base.numerator.multiplyingBy(multiplier).divMod(base.denominator).quotient
+	let rawRes = abs(base).numerator.multiplyingBy(multiplier).divMod(base.denominator).quotient
 
 	let res = BInt(limbs: rawRes).description
 
 	let offset = res.count - digits
-	let rhs = Double("0." + res.suffix(offset + 1))!
+	let rhs = Double("0." + res.suffix(res.count - offset))!
 	let lhs = res.prefix(offset)
+	
 	var retVal = BInt(String(lhs))!
-	if rhs > 0.0
+	
+	if base.isNegative()
 	{
-		retVal += 1
+		retVal = -retVal
+	} else {
+		if rhs > 0.0
+		{
+			retVal += 1
+		}
 	}
-
+	
 	return retVal
 }
 

--- a/Swift-BigNumber.xcodeproj/project.pbxproj
+++ b/Swift-BigNumber.xcodeproj/project.pbxproj
@@ -21,7 +21,21 @@
 		C2F92B511D0F7468003CDF7D /* MG Benchmark Tools.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F92B491D0F7468003CDF7D /* MG Benchmark Tools.swift */; };
 		C2F92B541D0F7468003CDF7D /* MG Matrix.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F92B4C1D0F7468003CDF7D /* MG Matrix.swift */; };
 		C2F92B561D0F7468003CDF7D /* MG QueueDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F92B4F1D0F7468003CDF7D /* MG QueueDispatch.swift */; };
+		F64629281FF016620074A180 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F64629271FF016620074A180 /* XCTest.framework */; };
+		F646295D1FF017EA0074A180 /* BigNumber.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F64629541FF017E90074A180 /* BigNumber.framework */; };
+		F646296C1FF018540074A180 /* BDoubleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64629241FF016070074A180 /* BDoubleTests.swift */; };
+		F646296D1FF019F40074A180 /* SMP.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F92B421D0F7452003CDF7D /* SMP.swift */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		F646295E1FF017EA0074A180 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = C2F92B301D0F7421003CDF7D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = F64629531FF017E90074A180;
+			remoteInfo = BigNumber;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		C2F92B361D0F7421003CDF7D /* CopyFiles */ = {
@@ -41,7 +55,6 @@
 		C26D70B81F62A6230012AA54 /* SMP Tests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "SMP Tests.swift"; sourceTree = "<group>"; };
 		C28710FC1F5ECFC400566A00 /* Benchmarks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Benchmarks.swift; sourceTree = "<group>"; };
 		C28F71EE1DF0557800CE18C6 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = Info.plist; path = Testing/Info.plist; sourceTree = "<group>"; };
-		C29D042C1E031DC50027CBDE /* MathGround */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; name = MathGround; path = "/Users/marcelkroker/Documents/Xcode/Public Github/Swift-Big-Integer/Xcode Project/build/Debug/MathGround"; sourceTree = "<absolute>"; };
 		C2A53BF21DAA8A7300AD08E4 /* MG Storage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MG Storage.swift"; sourceTree = "<group>"; };
 		C2BCD1831FA13F1E002F6986 /* MG Math Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MG Math Tests.swift"; sourceTree = "<group>"; };
 		C2BCD1851FA14252002F6986 /* MG Matrix Tests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MG Matrix Tests.swift"; sourceTree = "<group>"; };
@@ -52,6 +65,13 @@
 		C2F92B491D0F7468003CDF7D /* MG Benchmark Tools.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MG Benchmark Tools.swift"; sourceTree = "<group>"; };
 		C2F92B4C1D0F7468003CDF7D /* MG Matrix.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MG Matrix.swift"; sourceTree = "<group>"; };
 		C2F92B4F1D0F7468003CDF7D /* MG QueueDispatch.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "MG QueueDispatch.swift"; sourceTree = "<group>"; };
+		F64629231FF015E40074A180 /* MathGround */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = MathGround; sourceTree = BUILT_PRODUCTS_DIR; };
+		F64629241FF016070074A180 /* BDoubleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BDoubleTests.swift; sourceTree = "<group>"; };
+		F64629271FF016620074A180 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/MacOSX.platform/Developer/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
+		F64629541FF017E90074A180 /* BigNumber.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = BigNumber.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		F64629571FF017EA0074A180 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F646295C1FF017EA0074A180 /* BigNumberTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BigNumberTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		F64629631FF017EA0074A180 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -59,6 +79,22 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F64629281FF016620074A180 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F64629501FF017E90074A180 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F64629591FF017EA0074A180 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F646295D1FF017EA0074A180 /* BigNumber.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -68,9 +104,11 @@
 		C29F6AE41FEB1BD200AD0478 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
+				F64629241FF016070074A180 /* BDoubleTests.swift */,
 				C26D70B81F62A6230012AA54 /* SMP Tests.swift */,
 				C2BCD1831FA13F1E002F6986 /* MG Math Tests.swift */,
 				C2BCD1851FA14252002F6986 /* MG Matrix Tests.swift */,
+				F64629631FF017EA0074A180 /* Info.plist */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -79,6 +117,7 @@
 			isa = PBXGroup;
 			children = (
 				C2F92B421D0F7452003CDF7D /* SMP.swift */,
+				F64629571FF017EA0074A180 /* Info.plist */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -123,10 +162,32 @@
 				C29F6AE41FEB1BD200AD0478 /* Tests */,
 				C28F71EE1DF0557800CE18C6 /* Info.plist */,
 				C2A4928A1DF05294001992B1 /* Products */,
+				F64629231FF015E40074A180 /* MathGround */,
+				F64629261FF016610074A180 /* Frameworks */,
+				F64629541FF017E90074A180 /* BigNumber.framework */,
+				F646295C1FF017EA0074A180 /* BigNumberTests.xctest */,
 			);
 			sourceTree = "<group>";
 		};
+		F64629261FF016610074A180 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				F64629271FF016620074A180 /* XCTest.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 /* End PBXGroup section */
+
+/* Begin PBXHeadersBuildPhase section */
+		F64629511FF017E90074A180 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
 		C2F92B371D0F7421003CDF7D /* MathGround */ = {
@@ -143,8 +204,44 @@
 			);
 			name = MathGround;
 			productName = MathGround;
-			productReference = C29D042C1E031DC50027CBDE /* MathGround */;
+			productReference = F64629231FF015E40074A180 /* MathGround */;
 			productType = "com.apple.product-type.tool";
+		};
+		F64629531FF017E90074A180 /* BigNumber */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F64629651FF017EA0074A180 /* Build configuration list for PBXNativeTarget "BigNumber" */;
+			buildPhases = (
+				F646294F1FF017E90074A180 /* Sources */,
+				F64629501FF017E90074A180 /* Frameworks */,
+				F64629511FF017E90074A180 /* Headers */,
+				F64629521FF017E90074A180 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BigNumber;
+			productName = BigNumber;
+			productReference = F64629541FF017E90074A180 /* BigNumber.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		F646295B1FF017EA0074A180 /* BigNumberTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = F64629681FF017EA0074A180 /* Build configuration list for PBXNativeTarget "BigNumberTests" */;
+			buildPhases = (
+				F64629581FF017EA0074A180 /* Sources */,
+				F64629591FF017EA0074A180 /* Frameworks */,
+				F646295A1FF017EA0074A180 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				F646295F1FF017EA0074A180 /* PBXTargetDependency */,
+			);
+			name = BigNumberTests;
+			productName = BigNumberTests;
+			productReference = F646295C1FF017EA0074A180 /* BigNumberTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
 		};
 /* End PBXNativeTarget section */
 
@@ -152,13 +249,23 @@
 		C2F92B301D0F7421003CDF7D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 0810;
+				LastSwiftUpdateCheck = 0920;
 				LastUpgradeCheck = 0900;
 				ORGANIZATIONNAME = "Marcel Kröker";
 				TargetAttributes = {
 					C2F92B371D0F7421003CDF7D = {
 						CreatedOnToolsVersion = 8.0;
 						LastSwiftMigration = 0900;
+						ProvisioningStyle = Automatic;
+					};
+					F64629531FF017E90074A180 = {
+						CreatedOnToolsVersion = 9.2;
+						DevelopmentTeam = C6L3992RFB;
+						ProvisioningStyle = Automatic;
+					};
+					F646295B1FF017EA0074A180 = {
+						CreatedOnToolsVersion = 9.2;
+						DevelopmentTeam = C6L3992RFB;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -176,9 +283,28 @@
 			projectRoot = "";
 			targets = (
 				C2F92B371D0F7421003CDF7D /* MathGround */,
+				F64629531FF017E90074A180 /* BigNumber */,
+				F646295B1FF017EA0074A180 /* BigNumberTests */,
 			);
 		};
 /* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		F64629521FF017E90074A180 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F646295A1FF017EA0074A180 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		C2F92B341D0F7421003CDF7D /* Sources */ = {
@@ -202,7 +328,31 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		F646294F1FF017E90074A180 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F646296D1FF019F40074A180 /* SMP.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		F64629581FF017EA0074A180 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F646296C1FF018540074A180 /* BDoubleTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		F646295F1FF017EA0074A180 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = F64629531FF017E90074A180 /* BigNumber */;
+			targetProxy = F646295E1FF017EA0074A180 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
 		C2F92B3D1D0F7421003CDF7D /* Debug */ = {
@@ -313,6 +463,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				INFOPLIST_FILE = "$(SRCROOT)/Testing/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
@@ -327,11 +478,116 @@
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
 				GCC_OPTIMIZATION_LEVEL = fast;
+				INFOPLIST_FILE = "$(SRCROOT)/Testing/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_OBJC_BRIDGING_HEADER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_SWIFT3_OBJC_INFERENCE = Default;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Release;
+		};
+		F64629661FF017EA0074A180 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = C6L3992RFB;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mkrd.BigNumber;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
+		F64629671FF017EA0074A180 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = C6L3992RFB;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = "$(SRCROOT)/Sources/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mkrd.BigNumber;
+				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 4.0;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		F64629691FF017EA0074A180 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = C6L3992RFB;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mkrd.BigNumberTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = DEBUG;
+				SWIFT_VERSION = 4.0;
+			};
+			name = Debug;
+		};
+		F646296A1FF017EA0074A180 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++14";
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CODE_SIGN_IDENTITY = "Mac Developer";
+				CODE_SIGN_STYLE = Automatic;
+				COMBINE_HIDPI_IMAGES = YES;
+				DEVELOPMENT_TEAM = C6L3992RFB;
+				GCC_C_LANGUAGE_STANDARD = gnu11;
+				INFOPLIST_FILE = Tests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.13;
+				PRODUCT_BUNDLE_IDENTIFIER = com.mkrd.BigNumberTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_VERSION = 4.0;
 			};
 			name = Release;
@@ -353,6 +609,24 @@
 			buildConfigurations = (
 				C2F92B401D0F7421003CDF7D /* Debug */,
 				C2F92B411D0F7421003CDF7D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F64629651FF017EA0074A180 /* Build configuration list for PBXNativeTarget "BigNumber" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F64629661FF017EA0074A180 /* Debug */,
+				F64629671FF017EA0074A180 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		F64629681FF017EA0074A180 /* Build configuration list for PBXNativeTarget "BigNumberTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				F64629691FF017EA0074A180 /* Debug */,
+				F646296A1FF017EA0074A180 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Tests/BDoubleTests.swift
+++ b/Tests/BDoubleTests.swift
@@ -143,6 +143,30 @@ class BDoubleTests : XCTestCase {
 		XCTAssert(bigD?.decimalDescription == "123456789")
 		bigD?.precision = -100
 		XCTAssert(bigD?.decimalDescription == "123456789")
+		
+		bigD = BDouble("-123456789.123456789")
+		bigD?.precision = 2
+		XCTAssert(bigD?.decimalDescription == "-123456789.12", (bigD?.decimalDescription)!)
+		bigD?.precision = 4
+		XCTAssert(bigD?.decimalDescription == "-123456789.1234", (bigD?.decimalDescription)!)
+		bigD?.precision = 10
+		XCTAssert(bigD?.decimalDescription == "-123456789.1234567890", (bigD?.decimalDescription)!)
+		bigD?.precision = 20
+		XCTAssert(bigD?.decimalDescription == "-123456789.12345678900000000000")
+		bigD?.precision = 0
+		XCTAssert(bigD?.decimalDescription == "-123456789")
+		bigD?.precision = -1
+		XCTAssert(bigD?.decimalDescription == "-123456789")
+		bigD?.precision = -100
+		XCTAssert(bigD?.decimalDescription == "-123456789")
+		
+		bigD = BDouble("0.0000000003") // nine zeroes
+		bigD?.precision = 0
+		XCTAssert(bigD?.decimalDescription == "0.0", (bigD?.decimalDescription)!)
+		bigD?.precision = 10
+		XCTAssert(bigD?.decimalDescription == "0.0000000003", (bigD?.decimalDescription)!)
+		bigD?.precision = 5
+		XCTAssert(bigD?.decimalDescription == "0.00000", (bigD?.decimalDescription)!)
 	}
 
     func testPerformanceExample() {

--- a/Tests/BDoubleTests.swift
+++ b/Tests/BDoubleTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import Foundation
 @testable import BigNumber
 
 class BDoubleTests : XCTestCase {
@@ -31,17 +32,66 @@ class BDoubleTests : XCTestCase {
 		XCTAssert(BDouble("+1.2e+10")?.fractionDescription == "120000000000")
 		XCTAssert(BDouble("-1.2e10")?.fractionDescription == "-120000000000")
 		XCTAssert(BDouble("1.2")?.fractionDescription == "6/5")
+		
+		for _ in 0..<100 {
+			let rn = Double(Double(arc4random()) / Double(UINT32_MAX))
+			XCTAssertNotNil(BDouble(rn))
+			
+			let rn2 = pow(rn * 100, 2.0)
+			XCTAssertNotNil(BDouble(rn2))
+		}
     }
+	
+	func testCompare() {
+		XCTAssert(BDouble(1.0) == BDouble(1.0))
+		XCTAssert(BDouble(1.1) != BDouble(1.0))
+		XCTAssert(BDouble(2.0) > BDouble(1.0))
+		XCTAssert(BDouble(-1) < BDouble(1.0))
+		XCTAssert(BDouble(0.0) <= BDouble(1.0))
+		XCTAssert(BDouble(1.1) >= BDouble(1.0))
+		
+		XCTAssert(1.0 == BDouble(1.0))
+		XCTAssert(1.1 != BDouble(1.0))
+		XCTAssert(2.0 > BDouble(1.0))
+		XCTAssert(0.0 < BDouble(1.0))
+		XCTAssert(-1.0 <= BDouble(1.0))
+		XCTAssert(1.1 >= BDouble(1.0))
+		
+		XCTAssert(BDouble(1.0) == 1.0)
+		XCTAssert(BDouble(1.1) != 1.0)
+		XCTAssert(BDouble(2.0) > 1.0)
+		XCTAssert(BDouble(-1) < 1.0)
+		XCTAssert(BDouble(0.0) <= 1.0)
+		XCTAssert(BDouble(1.1) >= 1.0)
+		
+		for _ in 1..<100 {
+			let rn = Double(Double(arc4random()) / Double(UINT32_MAX))
+			let rn2 = pow(rn * 100, 2.0)
+			
+			XCTAssert(BDouble(rn) < BDouble(rn2))
+			XCTAssert(BDouble(rn) <= BDouble(rn2))
+			XCTAssert(BDouble(rn2) > BDouble(rn))
+			XCTAssert(BDouble(rn2) >= BDouble(rn))
+			XCTAssert(BDouble(rn) == BDouble(rn))
+			XCTAssert(BDouble(rn2) != BDouble(rn))
+		}
+	}
 	
 	func testPow() {
 		// Test that a number to the zero power is 1
 		for i in 0..<100 {
 			XCTAssert(pow(BDouble(Double(i)), 0) == 1.0)
+			
+			let rn = Double(Double(arc4random()) / Double(UINT32_MAX))
+			XCTAssert(pow(BDouble(rn), 0) == 1.0)
 		}
 		
 		// Test that a number to the one power is itself
 		for i in 0..<100 {
 			XCTAssert(pow(BDouble(Double(i)), 1) == Double(i))
+			
+			let rn = Double(Double(arc4random()) / Double(UINT32_MAX))
+			XCTAssert(pow(BDouble(rn), 1) == rn)
 		}
 	}
 	
@@ -53,6 +103,8 @@ class BDoubleTests : XCTestCase {
 		XCTAssert(bigD?.decimalDescription == "123456789.1234")
 		bigD?.precision = 10
 		XCTAssert(bigD?.decimalDescription == "123456789.1234567890")
+		bigD?.precision = 20
+		XCTAssert(bigD?.decimalDescription == "123456789.12345678900000000000")
 		bigD?.precision = 0
 		XCTAssert(bigD?.decimalDescription == "123456789")
 		bigD?.precision = -1

--- a/Tests/BDoubleTests.swift
+++ b/Tests/BDoubleTests.swift
@@ -165,6 +165,8 @@ class BDoubleTests : XCTestCase {
 		XCTAssert(bigD?.decimalDescription == "0.0", (bigD?.decimalDescription)!)
 		bigD?.precision = 10
 		XCTAssert(bigD?.decimalDescription == "0.0000000003", (bigD?.decimalDescription)!)
+		bigD?.precision = 15
+		XCTAssert(bigD?.decimalDescription == "0.000000000300000", (bigD?.decimalDescription)!)
 		bigD?.precision = 5
 		XCTAssert(bigD?.decimalDescription == "0.00000", (bigD?.decimalDescription)!)
 	}

--- a/Tests/BDoubleTests.swift
+++ b/Tests/BDoubleTests.swift
@@ -1,0 +1,71 @@
+import XCTest
+@testable import BigNumber
+
+class BDoubleTests : XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+
+    func testCreation() {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+		XCTAssertNil(BDouble("alphabet"))
+		XCTAssertNil(BDouble("-0.123ad2e+123"))
+		XCTAssertNil(BDouble("0.123.ad2e123"))
+		XCTAssertNil(BDouble("0.123ae123"))
+		XCTAssertNil(BDouble("0.123ae1.23"))
+		XCTAssertNotNil(BDouble("1.2e+123"))
+		XCTAssertNotNil(BDouble("-1.2e+123"))
+		XCTAssertNotNil(BDouble("+1.2e-123"))
+		XCTAssert(BDouble("0") == 0.0)
+		XCTAssert(BDouble("10") == 10.0)
+		XCTAssert(BDouble("1.2e10")?.fractionDescription == "120000000000")
+		XCTAssert(BDouble("1.2e+10")?.fractionDescription == "120000000000")
+		XCTAssert(BDouble("+1.2e+10")?.fractionDescription == "120000000000")
+		XCTAssert(BDouble("-1.2e10")?.fractionDescription == "-120000000000")
+		XCTAssert(BDouble("1.2")?.fractionDescription == "6/5")
+    }
+	
+	func testPow() {
+		// Test that a number to the zero power is 1
+		for i in 0..<100 {
+			XCTAssert(pow(BDouble(Double(i)), 0) == 1.0)
+		}
+		
+		// Test that a number to the one power is itself
+		for i in 0..<100 {
+			XCTAssert(pow(BDouble(Double(i)), 1) == Double(i))
+		}
+	}
+	
+	func testPrecision() {
+		var bigD = BDouble("123456789.123456789")
+		bigD?.precision = 2
+		XCTAssert(bigD?.decimalDescription == "123456789.12")
+		bigD?.precision = 4
+		XCTAssert(bigD?.decimalDescription == "123456789.1234")
+		bigD?.precision = 10
+		XCTAssert(bigD?.decimalDescription == "123456789.1234567890")
+		bigD?.precision = 0
+		XCTAssert(bigD?.decimalDescription == "123456789")
+		bigD?.precision = -1
+		XCTAssert(bigD?.decimalDescription == "123456789")
+		bigD?.precision = -100
+		XCTAssert(bigD?.decimalDescription == "123456789")
+	}
+
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/Tests/BDoubleTests.swift
+++ b/Tests/BDoubleTests.swift
@@ -170,6 +170,15 @@ class BDoubleTests : XCTestCase {
 		bigD?.precision = 5
 		XCTAssert(bigD?.decimalDescription == "0.00000", (bigD?.decimalDescription)!)
 	}
+	
+	func testOperations() {
+		XCTAssert(BDouble(1.5) + BDouble(2.0) == BDouble(3.5))
+		XCTAssert(BDouble(1.5) - BDouble(2.0) == BDouble(-0.5))
+		XCTAssert(BDouble(1.5) * BDouble(2.0) == BDouble(3.0))
+		XCTAssert(BDouble(1.0) / BDouble(2.0) == BDouble(0.5))
+		XCTAssert(-BDouble(6.54) == BDouble(-6.54))
+		testPow()
+	}
 
     func testPerformanceExample() {
         // This is an example of a performance test case.

--- a/Tests/BDoubleTests.swift
+++ b/Tests/BDoubleTests.swift
@@ -14,7 +14,7 @@ class BDoubleTests : XCTestCase {
         super.tearDown()
     }
 
-    func testCreation() {
+    func testInitialization() {
         // This is an example of a functional test case.
         // Use XCTAssert and related functions to verify your tests produce the correct results.
 		XCTAssertNil(BDouble("alphabet"))
@@ -93,6 +93,38 @@ class BDoubleTests : XCTestCase {
 			let rn = Double(Double(arc4random()) / Double(UINT32_MAX))
 			XCTAssert(pow(BDouble(rn), 1) == rn)
 		}
+	}
+	
+	func testRounding() {
+		XCTAssert(BDouble("-1.0")?.rounded() == BInt("-1"))
+		XCTAssert(BDouble("-1.1")?.rounded() == BInt("-1"))
+		XCTAssert(BDouble("-1.5")?.rounded() == BInt("-1"))
+		XCTAssert(BDouble("-1.6")?.rounded() == BInt("-2"))
+		XCTAssert(BDouble("0")?.rounded() == BInt("0"))
+		XCTAssert(BDouble("1.0")?.rounded() == BInt("1"))
+		XCTAssert(BDouble("1.1")?.rounded() == BInt("1"))
+		XCTAssert(BDouble("1.5")?.rounded() == BInt("1"))
+		XCTAssert(BDouble("1.6")?.rounded() == BInt("2"))
+		
+		XCTAssert(floor(BDouble(-1.0)) == BInt("-1"))
+		XCTAssert(floor(BDouble(-1.1)) == BInt("-2"))
+		XCTAssert(floor(BDouble(-1.5)) == BInt("-2"))
+		XCTAssert(floor(BDouble(-1.6)) == BInt("-2"))
+		XCTAssert(floor(BDouble(0)) == BInt("0"))
+		XCTAssert(floor(BDouble(1.0)) == BInt("1"))
+		XCTAssert(floor(BDouble(1.1)) == BInt("1"))
+		XCTAssert(floor(BDouble(1.5)) == BInt("1"))
+		XCTAssert(floor(BDouble(1.6)) == BInt("1"))
+		
+		XCTAssert(ceil(BDouble(-1.0)) == BInt("-1"))
+		XCTAssert(ceil(BDouble(-1.1)) == BInt("-1"))
+		XCTAssert(ceil(BDouble(-1.5)) == BInt("-1"))
+		XCTAssert(ceil(BDouble(-1.6)) == BInt("-1"))
+		XCTAssert(ceil(BDouble(0)) == BInt("0"))
+		XCTAssert(ceil(BDouble(1.0)) == BInt("1"))
+		XCTAssert(ceil(BDouble(1.1)) == BInt("2"))
+		XCTAssert(ceil(BDouble(1.5)) == BInt("2"))
+		XCTAssert(ceil(BDouble(1.6)) == BInt("2"))
 	}
 	
 	func testPrecision() {

--- a/Tests/Info.plist
+++ b/Tests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>


### PR DESCRIPTION
Using XCTest framework for testing. Product -> Test or Command + U to run the new test cases. 

Finding it really hard to test BDouble due to rounding.

I don't really know how to integrate CI with these test cases. That would be great - so every PR has to pass the tests cases - and add new ones for the things that were implemented.

If you could create another release after this, that would be great. Thanks!

Open to suggestions. 

### Test cases for BDouble:
* initialization 
* pow
* operations
* precision
* rounding
* comparison

### Fixed:

Testing works! Found some bugs and fixed them :)

* Negative number support
* Small number support (please check)
* String construction for BDouble that contains and "e" but is not a valid number