### PR TITLE
Radix optimizations and nearlyEqual

### DIFF
--- a/Swift-BigNumber.xcodeproj/project.pbxproj
+++ b/Swift-BigNumber.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		F646296C1FF018540074A180 /* BDoubleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64629241FF016070074A180 /* BDoubleTests.swift */; };
 		F646296D1FF019F40074A180 /* SMP.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F92B421D0F7452003CDF7D /* SMP.swift */; };
 		F6632C4A204918BF00B73607 /* SMP.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2F92B421D0F7452003CDF7D /* SMP.swift */; };
+		F6632C4D20499FE300B73607 /* BIntTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6632C4C20499FE300B73607 /* BIntTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -90,6 +91,7 @@
 		F64629571FF017EA0074A180 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F646295C1FF017EA0074A180 /* BigNumberTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BigNumberTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F64629631FF017EA0074A180 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		F6632C4C20499FE300B73607 /* BIntTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BIntTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -156,6 +158,7 @@
 			isa = PBXGroup;
 			children = (
 				F64629241FF016070074A180 /* BDoubleTests.swift */,
+				F6632C4C20499FE300B73607 /* BIntTests.swift */,
 				C26D70B81F62A6230012AA54 /* SMP Tests.swift */,
 				C2BCD1831FA13F1E002F6986 /* MG Math Tests.swift */,
 				C2BCD1851FA14252002F6986 /* MG Matrix Tests.swift */,
@@ -480,6 +483,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				F6632C4A204918BF00B73607 /* SMP.swift in Sources */,
+				F6632C4D20499FE300B73607 /* BIntTests.swift in Sources */,
 				F646296C1FF018540074A180 /* BDoubleTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Swift-BigNumber.xcodeproj/xcshareddata/xcbaselines/F646295B1FF017EA0074A180.xcbaseline/9D27035E-0C66-4C91-8299-009DD28C700B.plist
+++ b/Swift-BigNumber.xcodeproj/xcshareddata/xcbaselines/F646295B1FF017EA0074A180.xcbaseline/9D27035E-0C66-4C91-8299-009DD28C700B.plist
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>classNames</key>
+	<dict>
+		<key>BDoubleTests</key>
+		<dict>
+			<key>testPerformanceStringInit()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.52745</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPerformanceStringRadixInit()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.59005</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+		<key>BIntTests</key>
+		<dict>
+			<key>testPerformanceStringInit()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.28374</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+			<key>testPerformanceStringRadixInit()</key>
+			<dict>
+				<key>com.apple.XCTPerformanceMetric_WallClockTime</key>
+				<dict>
+					<key>baselineAverage</key>
+					<real>0.278</real>
+					<key>baselineIntegrationDisplayName</key>
+					<string>Local Baseline</string>
+				</dict>
+			</dict>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Swift-BigNumber.xcodeproj/xcshareddata/xcbaselines/F646295B1FF017EA0074A180.xcbaseline/Info.plist
+++ b/Swift-BigNumber.xcodeproj/xcshareddata/xcbaselines/F646295B1FF017EA0074A180.xcbaseline/Info.plist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>runDestinationsByUUID</key>
+	<dict>
+		<key>9D27035E-0C66-4C91-8299-009DD28C700B</key>
+		<dict>
+			<key>localComputer</key>
+			<dict>
+				<key>busSpeedInMHz</key>
+				<integer>100</integer>
+				<key>cpuCount</key>
+				<integer>1</integer>
+				<key>cpuKind</key>
+				<string>Intel Core i7</string>
+				<key>cpuSpeedInMHz</key>
+				<integer>2800</integer>
+				<key>logicalCPUCoresPerPackage</key>
+				<integer>4</integer>
+				<key>modelCode</key>
+				<string>MacBookPro11,1</string>
+				<key>physicalCPUCoresPerPackage</key>
+				<integer>2</integer>
+				<key>platformIdentifier</key>
+				<string>com.apple.platform.macosx</string>
+			</dict>
+			<key>targetArchitecture</key>
+			<string>x86_64</string>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/Tests/BDoubleTests.swift
+++ b/Tests/BDoubleTests.swift
@@ -171,6 +171,109 @@ class BDoubleTests : XCTestCase {
 		XCTAssert(bigD?.decimalDescription == "0.00000", (bigD?.decimalDescription)!)
 	}
 	
+	func testNearlyEqual() {
+		//BDouble.precision = 50
+		let BDMax = BDouble(Double.greatestFiniteMagnitude)
+		let BDMin = BDouble(Double.leastNormalMagnitude)
+		let eFourty = BDouble("0.00000 00000 00000 00000 00000 00000 00000 00001".replacingOccurrences(of: " ", with: ""))!
+		
+		//print(BDMax.decimalDescription, BDMin.decimalDescription, eFourty.decimalDescription)
+		
+		XCTAssert(BDouble.nearlyEqual(BDouble(100), BDouble(100), epsilon: 0.00001))
+		XCTAssert(BDouble.nearlyEqual(BDouble(100), BDouble(100.00000001), epsilon: 0.00001))
+		XCTAssert(BDouble.nearlyEqual(BDouble(100), BDouble(100.0000001), epsilon: 0.00001))
+		XCTAssert(BDouble.nearlyEqual(BDouble(100), BDouble(100.000001), epsilon: 0.00001))
+		XCTAssert(BDouble.nearlyEqual(BDouble(100), BDouble(100.0001), epsilon: 0.00001))
+		XCTAssert(BDouble.nearlyEqual(BDouble(100), BDouble(100.001), epsilon: 0.00001))
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(100), BDouble(100.01), epsilon: 0.00001))
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(100), BDouble(100.1), epsilon: 0.00001))
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(100), BDouble(101), epsilon: 0.00001))
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(100), BDouble(11), epsilon: 0.00001))
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(100), BDouble(1), epsilon: 0.00001))
+		
+		// Regular large numbers - generally not problematic
+		XCTAssert(BDouble.nearlyEqual(BDouble(1000000), BDouble(1000001)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(1000001), BDouble(1000000)));
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(10000), BDouble(10001)));
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(10001), BDouble(10000)));
+		
+		// Negative large numbers
+		XCTAssert(BDouble.nearlyEqual(BDouble(-1000000), BDouble(-1000001)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(-1000001), BDouble(-1000000)));
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(-10000), BDouble(-10001)));
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(-10001), BDouble(-10000)));
+		
+		// Numbers around 1
+		XCTAssert(BDouble.nearlyEqual(BDouble(1.0000001), BDouble(1.0000002)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(1.0000002), BDouble(1.0000001)));
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(1.0002), BDouble(1.0001)));
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(1.0001), BDouble(1.0002)));
+		
+		// Number around -1
+		XCTAssert(BDouble.nearlyEqual(BDouble(-1.000001), BDouble(-1.000002)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(-1.000002), BDouble(-1.000001)));
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(-1.0001), BDouble(-1.0002)));
+		XCTAssert(false == BDouble.nearlyEqual(BDouble(-1.0002), BDouble(-1.0001)));
+		
+		// Numbers between 0 and 1
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.000000001000001), BDouble(0.000000001000002)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.000000001000002), BDouble(0.000000001000001)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.000000000001002), BDouble(0.000000000001001)));
+		XCTAssert( BDouble.nearlyEqual(BDouble(0.000000000001001), BDouble(0.000000000001002)));
+		
+		// Numbers between -1 and 0
+		XCTAssert(BDouble.nearlyEqual(BDouble(-0.000000001000001), BDouble(-0.000000001000002)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(-0.000000001000002), BDouble(-0.000000001000001)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(-0.000000000001002), BDouble(-0.000000000001001)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(-0.000000000001001), BDouble(-0.000000000001002)));
+		
+		// small difference away from zero
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.3), BDouble(0.30000003)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(-0.3), BDouble(-0.30000003)));
+		
+		// comparisons involving zero
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), BDouble(0.0)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), BDouble(-0.0)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(-0.0), BDouble(-0.0)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.00000001), BDouble(0.0)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), BDouble(0.00000001)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(-0.00000001), BDouble(0.0)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), BDouble(-0.00000001)));
+		
+		XCTAssert(BDouble(0.0) != eFourty)
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), eFourty, epsilon: 0.01));
+		XCTAssert(BDouble.nearlyEqual(eFourty, BDouble(0.0), epsilon: 0.01));
+		XCTAssert(BDouble.nearlyEqual(eFourty, BDouble(0.0), epsilon: 0.000001));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), eFourty, epsilon: 0.000001));
+		
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), -eFourty, epsilon:0.1));
+		XCTAssert(BDouble.nearlyEqual(-eFourty, BDouble(0.0), epsilon:0.1));
+		XCTAssert(BDouble.nearlyEqual(-eFourty, BDouble(0.0), epsilon: 0.00000001));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), -eFourty, epsilon:0.00000001));
+		
+		// comparisons involving "extreme" values
+		XCTAssert(BDouble.nearlyEqual(BDMax, BDMax));
+		XCTAssert(false == BDouble.nearlyEqual(BDMax, -BDMax));
+		XCTAssert(false == BDouble.nearlyEqual(-BDMax, BDMax));
+		XCTAssert(false == BDouble.nearlyEqual(BDMax, BDMax / 2));
+		XCTAssert(false == BDouble.nearlyEqual(BDMax, -BDMax / 2));
+		XCTAssert(false == BDouble.nearlyEqual(-BDMax, BDMax / 2));
+		
+		// comparions very close to zero
+		XCTAssert(BDouble.nearlyEqual(BDMin, BDMin));
+		XCTAssert(BDouble.nearlyEqual(BDMin, -BDMin));
+		XCTAssert(BDouble.nearlyEqual(-BDMin, BDMin));
+		XCTAssert(BDouble.nearlyEqual(BDMin, BDouble(0.0)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), BDMin));
+		XCTAssert(BDouble.nearlyEqual(-BDMin, BDouble(0.0)));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.0), -BDMin));
+		
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.000000001), -BDMin));
+		XCTAssert(BDouble.nearlyEqual(BDouble(0.000000001), BDMin));
+		XCTAssert(BDouble.nearlyEqual(BDMin, BDouble(0.000000001)));
+		XCTAssert(BDouble.nearlyEqual(-BDMin, BDouble(0.000000001)));
+	}
+	
 	func testRadix() {
 		XCTAssert(BDouble("aa", radix: 16) == 170)
 		XCTAssert(BDouble("0xaa", radix: 16) == 170)
@@ -213,11 +316,22 @@ class BDoubleTests : XCTestCase {
 		testPow()
 	}
 
-    func testPerformanceExample() {
-        // This is an example of a performance test case.
+    func testPerformanceStringInit() {
         self.measure {
-            // Put the code you want to measure the time of here.
+			for _ in (0...1000) {
+				let _ = BDouble(String(arc4random()))
+				let _ = BDouble(String(arc4random())+"."+String(arc4random()))
+			}
         }
     }
+	
+	func testPerformanceStringRadixInit() {
+		self.measure {
+			for _ in (0...1000) {
+				let _ = BDouble(String(arc4random()), radix: 10)
+				let _ = BDouble(String(arc4random())+"."+String(arc4random()), radix: 10)
+			}
+		}
+	}
 
 }

--- a/Tests/BIntTests.swift
+++ b/Tests/BIntTests.swift
@@ -1,0 +1,69 @@
+//
+//  BInt.swift
+//  BigNumberTests
+//
+//  Created by Zachary Gorak on 3/2/18.
+//  Copyright © 2018 Marcel Kröker. All rights reserved.
+//
+
+import XCTest
+
+class BIntTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+	func testRadix() {
+		XCTAssert(BInt("ffff",radix:16) == 65535)
+		XCTAssert(BInt("ff",radix:16) == 255.0)
+		XCTAssert(BInt("ff",radix:16) != 100.0)
+		XCTAssert(BInt("ffff",radix:16)! > 255.0)
+		XCTAssert(BInt("f",radix:16)! < 255.0)
+		XCTAssert(BInt("0",radix:16)! <= 1.0)
+		XCTAssert(BInt("f", radix: 16)! >= 1.0)
+		XCTAssert(BInt("rfff",radix:16) == nil)
+		
+		XCTAssert(BInt("ffff",radix:16) == 65535)
+		XCTAssert(BInt("rfff",radix:16) == nil)
+		XCTAssert(BInt("ff",radix:10) == nil)
+		XCTAssert(BInt("255",radix:6) == 107)
+		XCTAssert(BInt("999",radix:10) == 999)
+		XCTAssert(BInt("ff",radix:16) == 255.0)
+		XCTAssert(BInt("ff",radix:16) != 100.0)
+		XCTAssert(BInt("ffff",radix:16)! > 255.0)
+		XCTAssert(BInt("f",radix:16)! < 255.0)
+		XCTAssert(BInt("0",radix:16)! <= 1.0)
+		XCTAssert(BInt("f",radix:16)! >= 1.0)
+		XCTAssert(BInt("44",radix:5) == 24)
+		XCTAssert(BInt("44",radix:5) != 100.0)
+		XCTAssert(BInt("321",radix:5)! == 86)
+		XCTAssert(BInt("3",radix:5)! < 255.0)
+		XCTAssert(BInt("0",radix:5)! <= 1.0)
+		XCTAssert(BInt("4",radix:5)! >= 1.0)
+		XCTAssert(BInt("923492349",radix:32)! == 9967689075849)
+	}
+	
+	func testPerformanceStringInit() {
+		self.measure {
+			for _ in (0...15000) {
+				let _ = BInt(String(arc4random()))
+			}
+		}
+	}
+	
+	func testPerformanceStringRadixInit() {
+		self.measure {
+			for _ in (0...15000) {
+				let _ = BInt(String(arc4random()), radix: 10)
+			}
+		}
+	}
+    
+}

--- a/Tests/SMP Tests.swift
+++ b/Tests/SMP Tests.swift
@@ -357,23 +357,4 @@ public class SMP_Tests
 			}
 		}
 	}
-	
-	func testRadix() {
-		XCTAssert(BInt("ffff",radix:16) == 65535)
-		XCTAssert(BInt("ff",radix:16) == 255.0)
-		XCTAssert(BInt("ff",radix:16) != 100.0)
-		XCTAssert(BInt("ffff",radix:16)! > 255.0)
-		XCTAssert(BInt("f",radix:16)! < 255.0)
-		XCTAssert(BInt("0",radix:16)! <= 1.0)
-		XCTAssert(BInt("f")! >= 1.0)
-		XCTAssert(BInt("rfff",radix:16) == nil)
-		
-		XCTAssert(BInt("44",radix:5) == 68.0)
-		XCTAssert(BInt("44",radix:5) != 100.0)
-		XCTAssert(BInt("321",radix:5)! > 255.0)
-		XCTAssert(BInt("3",radix:5)! < 255.0)
-		XCTAssert(BInt("0",radix:5)! <= 1.0)
-		XCTAssert(BInt("4",radix:5)! >= 1.0)
-		XCTAssert(BInt("rfff",radix:5) == nil)
-	}
 }


### PR DESCRIPTION
* Optimized BInt/BDouble(String, radix: 10)
   * BInt/BDouble(String)? is 4-5 times faster than BInt/BDouble(String, radix: 10)? without these optimizations
* Created nearlyEqual method which uses a fixed epsilon
* Organized test cases